### PR TITLE
feat: fix: report 'no changes produced' with probable causes inste (#19)

### DIFF
--- a/src/autoloop/implement_issue.py
+++ b/src/autoloop/implement_issue.py
@@ -22,6 +22,14 @@ cfg = None
 LOCKFILE = REPO_DIR / ".autoloop.lock"
 LOG_FILE = REPO_DIR / "autoloop" / "run_history.jsonl"
 
+EMPTY_BRANCH_DIAGNOSTIC = """\
+No changes were produced by the implementation agent.
+This usually means the agent could not act, not that the code is wrong.
+Likely causes:
+ 1. Missing .claude/settings.json permissions (run: autoloop init to scaffold)
+ 2. An active Claude Code session in this directory (close it or run elsewhere)
+ 3. The inner claude invocation failed to start (check claude CLI auth)"""
+
 
 # --- Pure functions (testable without mocking) ---
 
@@ -472,6 +480,18 @@ def implement(issue: dict, previous_errors: str | None = None) -> ClaudeResult:
     return run_claude(prompt, cfg.impl_model, cfg.impl_timeout)
 
 
+def is_branch_empty(branch: str) -> bool:
+    """Return True if the branch has zero commits ahead of main."""
+    result = subprocess.run(
+        ["git", "rev-list", "--count", f"main..{branch}"],
+        capture_output=True,
+        text=True,
+        cwd=REPO_DIR,
+    )
+    count = result.stdout.strip() if result.returncode == 0 else ""
+    return count == "0" or count == ""
+
+
 def verify_implementation(branch: str) -> tuple[bool, str]:
     """Verify the agent actually produced valid work."""
     ahead = subprocess.run(
@@ -812,10 +832,17 @@ def implement_single_issue(issue: dict, require_design: bool = False) -> bool:
         print(f"  Branch: {branch}")
 
         last_errors = None
+        empty_branch_failure = False
         for attempt in range(1, cfg.max_retries + 1):
             print(f"  Attempt {attempt}/{cfg.max_retries}...")
             claude_results.append(implement(issue, previous_errors=last_errors))
             final_attempt = attempt
+
+            if is_branch_empty(branch):
+                print(f"  {EMPTY_BRANCH_DIAGNOSTIC}")
+                post_attempt_failure(issue["number"], attempt, EMPTY_BRANCH_DIAGNOSTIC)
+                empty_branch_failure = True
+                break
 
             valid, errors = verify_implementation(branch)
             if not valid:
@@ -843,7 +870,10 @@ def implement_single_issue(issue: dict, require_design: bool = False) -> bool:
         total_cache_read = sum(r.cache_read_tokens for r in claude_results)
 
         if not success:
-            print("  All retries exhausted. Labeling needs-human.")
+            if empty_branch_failure:
+                print("  Implementation produced no changes. Labeling needs-human.")
+            else:
+                print("  All retries exhausted. Labeling needs-human.")
             subprocess.run(
                 [
                     "gh",

--- a/tests/test_implement_issue.py
+++ b/tests/test_implement_issue.py
@@ -8,6 +8,7 @@ import autoloop.implement_issue as implement_issue
 from autoloop.claude_runner import ClaudeResult
 from autoloop.config import AutoLoopConfig
 from autoloop.implement_issue import (
+    EMPTY_BRANCH_DIAGNOSTIC,
     acquire_lock,
     build_branch_name,
     build_pr_body,
@@ -26,6 +27,7 @@ from autoloop.implement_issue import (
     implement,
     implement_single_issue,
     implement_targeted_issue,
+    is_branch_empty,
     log_run,
     parent_issue_number,
     parse_and_strip_metric_targets,
@@ -681,15 +683,19 @@ def test_implement_single_issue_uses_cfg_max_retries(monkeypatch, tmp_path):
         attempt_count[0] += 1
         return _claude_result()
 
-    def fake_run(cmd, **kwargs):
-        if isinstance(cmd, list) and cmd[:3] == ["git", "rev-list", "--count"]:
-            return type("R", (), {"returncode": 0, "stdout": "0\n", "stderr": ""})()
-        return type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
-
-    monkeypatch.setattr(implement_issue.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        implement_issue.subprocess,
+        "run",
+        lambda *a, **kw: type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})(),
+    )
     monkeypatch.setattr(implement_issue, "implement", fake_implement)
     monkeypatch.setattr(implement_issue, "create_branch", lambda issue: "autoloop/42-x")
     monkeypatch.setattr(implement_issue, "cleanup_branch", lambda branch: None)
+    monkeypatch.setattr(implement_issue, "is_branch_empty", lambda branch: False)
+    monkeypatch.setattr(
+        implement_issue, "verify_implementation", lambda branch: (False, "Tests failed")
+    )
+    monkeypatch.setattr(implement_issue, "post_attempt_failure", lambda n, a, e: None)
 
     implement_single_issue(_FAKE_ISSUE)
     assert attempt_count[0] == 2
@@ -752,6 +758,7 @@ def test_implement_single_issue_logs_summed_token_totals(monkeypatch, tmp_path):
     monkeypatch.setattr(implement_issue, "create_pr", lambda *a, **kw: None)
     monkeypatch.setattr(implement_issue, "label_in_review", lambda n: None)
     monkeypatch.setattr(implement_issue, "review_implementation", lambda issue, branch: (True, ""))
+    monkeypatch.setattr(implement_issue, "is_branch_empty", lambda branch: False)
 
     verify_calls = [0]
 
@@ -1126,3 +1133,135 @@ def test_label_in_review_uses_cfg_repo(monkeypatch):
     implement_issue.label_in_review(42)
 
     assert captured["cmd"][captured["cmd"].index("--repo") + 1] == "my-org/my-repo"
+
+
+# --- is_branch_empty tests ---
+
+
+def test_is_branch_empty_true_when_zero_commits(monkeypatch):
+    def fake_run(cmd, **kwargs):
+        return type("R", (), {"returncode": 0, "stdout": "0\n", "stderr": ""})()
+
+    monkeypatch.setattr(implement_issue.subprocess, "run", fake_run)
+    assert is_branch_empty("autoloop/42-feature") is True
+
+
+def test_is_branch_empty_true_when_command_fails(monkeypatch):
+    def fake_run(cmd, **kwargs):
+        return type("R", (), {"returncode": 1, "stdout": "", "stderr": "error"})()
+
+    monkeypatch.setattr(implement_issue.subprocess, "run", fake_run)
+    assert is_branch_empty("autoloop/42-feature") is True
+
+
+def test_is_branch_empty_false_when_commits_exist(monkeypatch):
+    def fake_run(cmd, **kwargs):
+        return type("R", (), {"returncode": 0, "stdout": "3\n", "stderr": ""})()
+
+    monkeypatch.setattr(implement_issue.subprocess, "run", fake_run)
+    assert is_branch_empty("autoloop/42-feature") is False
+
+
+# --- Empty branch short-circuit in implement_single_issue ---
+
+
+def test_implement_single_issue_empty_branch_no_retries(monkeypatch, tmp_path):
+    """Empty branch after attempt 1 short-circuits with no retries."""
+    monkeypatch.setattr(implement_issue, "cfg", _test_cfg(max_retries=3))
+    log_path = tmp_path / "run_history.jsonl"
+    monkeypatch.setattr(implement_issue, "LOG_FILE", log_path)
+
+    attempt_count = [0]
+
+    def fake_implement(issue, previous_errors=None):
+        attempt_count[0] += 1
+        return _claude_result()
+
+    monkeypatch.setattr(implement_issue, "implement", fake_implement)
+    monkeypatch.setattr(implement_issue, "create_branch", lambda issue: "autoloop/42-x")
+    monkeypatch.setattr(implement_issue, "cleanup_branch", lambda branch: None)
+    monkeypatch.setattr(implement_issue, "is_branch_empty", lambda branch: True)
+
+    posted_comments = []
+    monkeypatch.setattr(
+        implement_issue,
+        "post_attempt_failure",
+        lambda n, a, e: posted_comments.append(e),
+    )
+    monkeypatch.setattr(
+        implement_issue.subprocess,
+        "run",
+        lambda *a, **kw: type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})(),
+    )
+
+    result = implement_single_issue(_FAKE_ISSUE)
+    assert result is False
+    assert attempt_count[0] == 1
+    assert len(posted_comments) == 1
+    assert "No changes were produced" in posted_comments[0]
+    assert "Missing .claude/settings.json" in posted_comments[0]
+
+
+def test_implement_single_issue_empty_branch_posts_diagnostic(monkeypatch, tmp_path, capsys):
+    """Diagnostic message is printed and posted, not lint/test noise."""
+    monkeypatch.setattr(implement_issue, "cfg", _test_cfg(max_retries=3))
+    log_path = tmp_path / "run_history.jsonl"
+    monkeypatch.setattr(implement_issue, "LOG_FILE", log_path)
+
+    monkeypatch.setattr(
+        implement_issue, "implement", lambda issue, previous_errors=None: _claude_result()
+    )
+    monkeypatch.setattr(implement_issue, "create_branch", lambda issue: "autoloop/42-x")
+    monkeypatch.setattr(implement_issue, "cleanup_branch", lambda branch: None)
+    monkeypatch.setattr(implement_issue, "is_branch_empty", lambda branch: True)
+    monkeypatch.setattr(implement_issue, "post_attempt_failure", lambda n, a, e: None)
+    monkeypatch.setattr(
+        implement_issue.subprocess,
+        "run",
+        lambda *a, **kw: type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})(),
+    )
+
+    implement_single_issue(_FAKE_ISSUE)
+    output = capsys.readouterr().out
+    assert "No changes were produced" in output
+    assert "Implementation produced no changes" in output
+
+
+def test_implement_single_issue_nonempty_branch_still_retries(monkeypatch, tmp_path):
+    """Non-empty branch failures (real test/lint errors) retain retry behavior."""
+    monkeypatch.setattr(implement_issue, "cfg", _test_cfg(max_retries=3))
+    log_path = tmp_path / "run_history.jsonl"
+    monkeypatch.setattr(implement_issue, "LOG_FILE", log_path)
+
+    attempt_count = [0]
+
+    def fake_implement(issue, previous_errors=None):
+        attempt_count[0] += 1
+        return _claude_result()
+
+    def fake_verify(branch):
+        return False, "Tests failed:\nsome test output"
+
+    monkeypatch.setattr(implement_issue, "implement", fake_implement)
+    monkeypatch.setattr(implement_issue, "create_branch", lambda issue: "autoloop/42-x")
+    monkeypatch.setattr(implement_issue, "cleanup_branch", lambda branch: None)
+    monkeypatch.setattr(implement_issue, "is_branch_empty", lambda branch: False)
+    monkeypatch.setattr(implement_issue, "verify_implementation", fake_verify)
+    monkeypatch.setattr(implement_issue, "post_attempt_failure", lambda n, a, e: None)
+    monkeypatch.setattr(
+        implement_issue.subprocess,
+        "run",
+        lambda *a, **kw: type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})(),
+    )
+
+    result = implement_single_issue(_FAKE_ISSUE)
+    assert result is False
+    assert attempt_count[0] == 3
+
+
+def test_empty_branch_diagnostic_content():
+    """Verify the diagnostic lists all three probable causes."""
+    assert "No changes were produced" in EMPTY_BRANCH_DIAGNOSTIC
+    assert "Missing .claude/settings.json permissions" in EMPTY_BRANCH_DIAGNOSTIC
+    assert "active Claude Code session" in EMPTY_BRANCH_DIAGNOSTIC
+    assert "inner claude invocation failed to start" in EMPTY_BRANCH_DIAGNOSTIC

--- a/tests/test_implement_issue.py
+++ b/tests/test_implement_issue.py
@@ -706,20 +706,29 @@ def test_implement_single_issue_returns_false_after_all_retries(monkeypatch, tmp
     log_path = tmp_path / "run_history.jsonl"
     monkeypatch.setattr(implement_issue, "LOG_FILE", log_path)
 
-    def fake_run(cmd, **kwargs):
-        if isinstance(cmd, list) and cmd[:3] == ["git", "rev-list", "--count"]:
-            return type("R", (), {"returncode": 0, "stdout": "0\n", "stderr": ""})()
-        return type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+    attempt_count = [0]
 
-    monkeypatch.setattr(implement_issue.subprocess, "run", fake_run)
+    def fake_implement(issue, previous_errors=None):
+        attempt_count[0] += 1
+        return _claude_result()
+
     monkeypatch.setattr(
-        implement_issue, "implement", lambda issue, previous_errors=None: _claude_result()
+        implement_issue.subprocess,
+        "run",
+        lambda *a, **kw: type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})(),
     )
+    monkeypatch.setattr(implement_issue, "implement", fake_implement)
     monkeypatch.setattr(implement_issue, "create_branch", lambda issue: "autoloop/42-x")
     monkeypatch.setattr(implement_issue, "cleanup_branch", lambda branch: None)
+    monkeypatch.setattr(implement_issue, "is_branch_empty", lambda branch: False)
+    monkeypatch.setattr(
+        implement_issue, "verify_implementation", lambda branch: (False, "Tests failed")
+    )
+    monkeypatch.setattr(implement_issue, "post_attempt_failure", lambda n, a, e: None)
 
     result = implement_single_issue(_FAKE_ISSUE)
     assert result is False
+    assert attempt_count[0] == 3
 
 
 def test_implement_single_issue_catches_exception_returns_false(monkeypatch):


### PR DESCRIPTION
Closes #19

## Summary
fix: report 'no changes produced' with probable causes instead of lint/test failures when branch is empty

## Test Plan
- `uv run pytest` — all tests pass
- `uv run ruff check && uv run ruff format --check` — clean

## AutoLoop Run Stats
- Attempts: 2/3
- Duration: 329s
- Input tokens: 30
- Output tokens: 11,456
- Cost: $1.50

Automated implementation by AutoLoop.