### PR TITLE
feat: feat: init scaffolds a minimal .claude/settings.json so head (#23)

### DIFF
--- a/src/autoloop/init.py
+++ b/src/autoloop/init.py
@@ -7,6 +7,7 @@ Usage (from the target repo root):
 from __future__ import annotations
 
 import argparse
+import json
 import subprocess
 from pathlib import Path
 
@@ -53,7 +54,7 @@ error_truncation = 2000
 spec_truncation = 4000
 
 # Paths the builder must never modify — issues targeting these get needs-human
-protected_paths = ["autoloop.toml"]
+protected_paths = ["autoloop.toml", ".claude/settings.json"]
 
 # Scheduling: autoloop uses systemd user timers for scheduled runs.
 # The timer_prefix controls which timers `autoloop status` looks for.
@@ -198,10 +199,108 @@ def create_labels(repo: str, dry_run: bool = False) -> None:
                 print(f"  failed: {name} — {stderr}")
 
 
+BASE_ALLOWLIST = [
+    "Read",
+    "Edit",
+    "Write",
+    "Bash(git status)",
+    "Bash(git add:*)",
+    "Bash(git commit:*)",
+    "Bash(git checkout:*)",
+    "Bash(git branch:*)",
+    "Bash(git push:*)",
+    "Bash(git diff:*)",
+    "Bash(git log:*)",
+    "Bash(gh:*)",
+]
+
+DENY_LIST = [
+    "Bash(git push --force*)",
+    "Bash(git reset --hard*)",
+    "Bash(rm -rf*)",
+    "Bash(gh pr merge*)",
+]
+
+
+def _extract_command_prefixes(cmd_string: str) -> list[str]:
+    """Split a compound command on && / || / ; and return Bash allowlist entries."""
+    parts: list[str] = []
+    for sep in ("&&", "||", ";"):
+        expanded: list[str] = []
+        for part in parts or [cmd_string]:
+            expanded.extend(part.split(sep))
+        parts = expanded
+
+    entries: list[str] = []
+    for part in parts:
+        part = part.strip()
+        if not part:
+            continue
+        entries.append(f"Bash({part}*)")
+
+    # Deduplicate: if one entry is a prefix of another, keep only the shorter one
+    deduplicated: list[str] = []
+    sorted_entries = sorted(entries, key=len)
+    for entry in sorted_entries:
+        prefix = entry[: -len("*)")] if entry.endswith("*)") else entry
+        if not any(
+            entry != existing and prefix.startswith(existing[: -len("*)")])
+            for existing in deduplicated
+        ):
+            deduplicated.append(entry)
+    return deduplicated
+
+
+def build_settings_allowlist(verify_cmd: str, lint_cmd: str = "") -> dict:
+    """Build a .claude/settings.json dict from verify and lint commands."""
+    allow = list(BASE_ALLOWLIST)
+    allow.extend(_extract_command_prefixes(verify_cmd))
+    if lint_cmd:
+        allow.extend(_extract_command_prefixes(lint_cmd))
+
+    # Deduplicate while preserving order
+    seen: set[str] = set()
+    unique: list[str] = []
+    for entry in allow:
+        if entry not in seen:
+            seen.add(entry)
+            unique.append(entry)
+
+    return {"permissions": {"allow": unique, "deny": list(DENY_LIST)}}
+
+
+def write_claude_settings(target: Path, verify_cmd: str, lint_cmd: str = "") -> None:
+    """Create .claude/settings.json with a minimal allowlist, or skip if it exists."""
+    claude_dir = target / ".claude"
+    path = claude_dir / "settings.json"
+
+    needed = build_settings_allowlist(verify_cmd, lint_cmd)
+
+    if path.exists():
+        existing = json.loads(path.read_text())
+        existing_allow = set(existing.get("permissions", {}).get("allow", []))
+        needed_allow = set(needed["permissions"]["allow"])
+        missing = sorted(needed_allow - existing_allow)
+        if missing:
+            print("  .claude/settings.json already exists — skipping creation")
+            print("  Entries autoloop needs but are not present:")
+            for entry in missing:
+                print(f"    + {entry}")
+            print("  Please add them manually if the builder needs them.")
+        else:
+            print("  .claude/settings.json already exists with all needed entries")
+        return
+
+    claude_dir.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(needed, indent=2) + "\n")
+    print("  created .claude/settings.json")
+
+
 def run_init(
     repo: str,
     reviewer: str = "",
     verify_cmd: str = "uv run pytest",
+    lint_cmd: str = "",
     dry_run: bool = False,
     skip_labels: bool = False,
 ) -> None:
@@ -212,6 +311,9 @@ def run_init(
 
     print("Config:")
     write_toml(target, repo, reviewer, verify_cmd)
+
+    print("\nPermissions:")
+    write_claude_settings(target, verify_cmd, lint_cmd)
 
     print("\nWorkflow:")
     write_workflow(target)
@@ -224,9 +326,12 @@ def run_init(
         create_labels(repo, dry_run=dry_run)
 
     print("\nDone! Next steps:")
-    print("  1. Review autoloop.toml")
+    print("  1. Review autoloop.toml and .claude/settings.json")
     print("  2. Commit the generated files:")
-    print("     git add autoloop.toml .github/workflows/autoloop-cleanup.yml .gitignore")
+    print(
+        "     git add autoloop.toml .claude/settings.json"
+        " .github/workflows/autoloop-cleanup.yml .gitignore"
+    )
     print('     git commit -m "feat: add autoloop pipeline"')
     print("  3. Run: autoloop triage    (to triage open issues)")
     print("  4. Run: autoloop implement (to implement top ready issue)")
@@ -240,12 +345,17 @@ def main() -> None:
         "--verify-cmd", default="uv run pytest", help="Verify command (default: uv run pytest)"
     )
     parser.add_argument(
+        "--lint-cmd", default="", help="Lint command (e.g. 'ruff check && ruff format --check')"
+    )
+    parser.add_argument(
         "--dry-run", action="store_true", help="Print label commands without running"
     )
     parser.add_argument("--skip-labels", action="store_true", help="Skip GitHub label creation")
     args = parser.parse_args()
 
-    run_init(args.repo, args.reviewer, args.verify_cmd, args.dry_run, args.skip_labels)
+    run_init(
+        args.repo, args.reviewer, args.verify_cmd, args.lint_cmd, args.dry_run, args.skip_labels
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from autoloop.init import (
+    _extract_command_prefixes,
+    build_settings_allowlist,
+    run_init,
+    write_claude_settings,
+)
+
+
+class TestExtractCommandPrefixes:
+    def test_single_command(self):
+        result = _extract_command_prefixes("pytest")
+        assert result == ["Bash(pytest*)"]
+
+    def test_compound_and(self):
+        result = _extract_command_prefixes("ruff check && ruff format --check")
+        assert "Bash(ruff check*)" in result
+        assert "Bash(ruff format --check*)" in result
+
+    def test_compound_or(self):
+        result = _extract_command_prefixes("cmd1 || cmd2")
+        assert "Bash(cmd1*)" in result
+        assert "Bash(cmd2*)" in result
+
+    def test_compound_semicolon(self):
+        result = _extract_command_prefixes("cmd1 ; cmd2")
+        assert "Bash(cmd1*)" in result
+        assert "Bash(cmd2*)" in result
+
+    def test_prefix_deduplication(self):
+        result = _extract_command_prefixes("uv run ruff check && uv run ruff format --check")
+        assert "Bash(uv run ruff check*)" in result
+        assert "Bash(uv run ruff format --check*)" in result
+
+    def test_empty_string(self):
+        result = _extract_command_prefixes("")
+        assert result == []
+
+    def test_uv_run_pytest(self):
+        result = _extract_command_prefixes("uv run pytest")
+        assert result == ["Bash(uv run pytest*)"]
+
+    def test_npm_test(self):
+        result = _extract_command_prefixes("npm test")
+        assert result == ["Bash(npm test*)"]
+
+
+class TestBuildSettingsAllowlist:
+    def test_verify_cmd_included(self):
+        settings = build_settings_allowlist("pytest")
+        allow = settings["permissions"]["allow"]
+        assert "Bash(pytest*)" in allow
+
+    def test_lint_cmd_included(self):
+        settings = build_settings_allowlist("pytest", lint_cmd="ruff check")
+        allow = settings["permissions"]["allow"]
+        assert "Bash(pytest*)" in allow
+        assert "Bash(ruff check*)" in allow
+
+    def test_base_allowlist_present(self):
+        settings = build_settings_allowlist("pytest")
+        allow = settings["permissions"]["allow"]
+        assert "Read" in allow
+        assert "Edit" in allow
+        assert "Write" in allow
+        assert "Bash(git status)" in allow
+        assert "Bash(git add:*)" in allow
+        assert "Bash(git commit:*)" in allow
+        assert "Bash(gh:*)" in allow
+
+    def test_deny_list_present(self):
+        settings = build_settings_allowlist("pytest")
+        deny = settings["permissions"]["deny"]
+        assert "Bash(git push --force*)" in deny
+        assert "Bash(git reset --hard*)" in deny
+        assert "Bash(rm -rf*)" in deny
+
+    def test_no_duplicates(self):
+        settings = build_settings_allowlist("pytest", lint_cmd="pytest")
+        allow = settings["permissions"]["allow"]
+        assert allow.count("Bash(pytest*)") == 1
+
+    def test_empty_lint_cmd_no_extra_entries(self):
+        settings_no_lint = build_settings_allowlist("pytest", lint_cmd="")
+        settings_with_lint = build_settings_allowlist("pytest", lint_cmd="ruff check")
+        assert len(settings_with_lint["permissions"]["allow"]) > len(
+            settings_no_lint["permissions"]["allow"]
+        )
+
+
+class TestWriteClaudeSettings:
+    def test_creates_settings_fresh(self, tmp_path, capsys):
+        write_claude_settings(tmp_path, "pytest")
+        path = tmp_path / ".claude" / "settings.json"
+        assert path.exists()
+        data = json.loads(path.read_text())
+        assert "Bash(pytest*)" in data["permissions"]["allow"]
+        assert "Read" in data["permissions"]["allow"]
+        out = capsys.readouterr().out
+        assert "created .claude/settings.json" in out
+
+    def test_creates_claude_dir(self, tmp_path):
+        write_claude_settings(tmp_path, "pytest")
+        assert (tmp_path / ".claude").is_dir()
+
+    def test_skips_existing_with_all_entries(self, tmp_path, capsys):
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        settings_path = claude_dir / "settings.json"
+        needed = build_settings_allowlist("pytest")
+        settings_path.write_text(json.dumps(needed, indent=2) + "\n")
+
+        write_claude_settings(tmp_path, "pytest")
+        out = capsys.readouterr().out
+        assert "already exists with all needed entries" in out
+
+    def test_skips_existing_reports_missing(self, tmp_path, capsys):
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        settings_path = claude_dir / "settings.json"
+        settings_path.write_text(json.dumps({"permissions": {"allow": ["Read"]}}) + "\n")
+
+        write_claude_settings(tmp_path, "pytest")
+        out = capsys.readouterr().out
+        assert "skipping creation" in out
+        assert "Entries autoloop needs but are not present" in out
+        assert "Bash(pytest*)" in out
+
+    def test_never_overwrites_existing(self, tmp_path):
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        settings_path = claude_dir / "settings.json"
+        original = '{"permissions": {"allow": ["Read"]}}\n'
+        settings_path.write_text(original)
+
+        write_claude_settings(tmp_path, "pytest")
+        assert settings_path.read_text() == original
+
+    def test_verify_cmd_propagation(self, tmp_path):
+        write_claude_settings(tmp_path, "npm test")
+        path = tmp_path / ".claude" / "settings.json"
+        data = json.loads(path.read_text())
+        assert "Bash(npm test*)" in data["permissions"]["allow"]
+
+    def test_lint_cmd_propagation(self, tmp_path):
+        write_claude_settings(tmp_path, "pytest", lint_cmd="ruff check && ruff format --check")
+        path = tmp_path / ".claude" / "settings.json"
+        data = json.loads(path.read_text())
+        allow = data["permissions"]["allow"]
+        assert "Bash(ruff check*)" in allow
+        assert "Bash(ruff format --check*)" in allow
+
+
+class TestRunInitSettings:
+    @patch("autoloop.init.create_labels")
+    def test_init_creates_settings(self, mock_labels, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        run_init("acme/widgets", verify_cmd="pytest", skip_labels=True)
+        path = tmp_path / ".claude" / "settings.json"
+        assert path.exists()
+        data = json.loads(path.read_text())
+        assert "Bash(pytest*)" in data["permissions"]["allow"]
+
+    @patch("autoloop.init.create_labels")
+    def test_init_passes_lint_cmd(self, mock_labels, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        run_init("acme/widgets", verify_cmd="pytest", lint_cmd="ruff check", skip_labels=True)
+        path = tmp_path / ".claude" / "settings.json"
+        data = json.loads(path.read_text())
+        assert "Bash(ruff check*)" in data["permissions"]["allow"]
+
+    @patch("autoloop.init.create_labels")
+    def test_init_protected_paths_includes_settings(self, mock_labels, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        run_init("acme/widgets", verify_cmd="pytest", skip_labels=True)
+        toml_content = (tmp_path / "autoloop.toml").read_text()
+        assert ".claude/settings.json" in toml_content
+
+    @patch("autoloop.init.create_labels")
+    def test_init_next_steps_mentions_settings(self, mock_labels, tmp_path, monkeypatch, capsys):
+        monkeypatch.chdir(tmp_path)
+        run_init("acme/widgets", verify_cmd="pytest", skip_labels=True)
+        out = capsys.readouterr().out
+        assert ".claude/settings.json" in out


### PR DESCRIPTION
Closes #23

## Summary
feat: init scaffolds a minimal .claude/settings.json so headless implement runs can act

## Test Plan
- `uv run pytest` — all tests pass
- `uv run ruff check && uv run ruff format --check` — clean

## AutoLoop Run Stats
- Attempts: 1/3
- Duration: 213s
- Input tokens: 23
- Output tokens: 9,277
- Cost: $0.87

Automated implementation by AutoLoop.