### PR TITLE
feat: fix: detect active Claude Code session and fail fast instead (#25)

### DIFF
--- a/src/autoloop/implement_issue.py
+++ b/src/autoloop/implement_issue.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import platform
 import re
 import subprocess
 import time
@@ -165,6 +166,91 @@ def log_run(
     LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
     with open(LOG_FILE, "a") as f:
         f.write(json.dumps(entry) + "\n")
+
+
+# --- Active session detection ---
+
+
+def detect_active_claude_session(project_dir: str | None = None) -> bool | None:
+    """Check if an interactive Claude Code session is active in the project directory.
+
+    Returns True if a session is detected, False if none found, or None if
+    detection is inconclusive (tools unavailable).
+    """
+    if project_dir is None:
+        project_dir = str(REPO_DIR)
+
+    project_dir = os.path.realpath(project_dir)
+
+    try:
+        result = subprocess.run(
+            ["pgrep", "-af", "claude"],
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        return None
+
+    if result.returncode != 0 or not result.stdout.strip():
+        return False
+
+    pids = []
+    for line in result.stdout.strip().splitlines():
+        parts = line.split(None, 1)
+        if not parts:
+            continue
+        try:
+            pid = int(parts[0])
+        except ValueError:
+            continue
+        if len(parts) > 1 and "--dangerously-skip-permissions" not in parts[1]:
+            pids.append(pid)
+
+    if not pids:
+        return False
+
+    if platform.system() == "Darwin":
+        return _check_cwd_lsof(pids, project_dir)
+    return _check_cwd_proc(pids, project_dir)
+
+
+def _check_cwd_lsof(pids: list[int], project_dir: str) -> bool | None:
+    """Use lsof to check if any pid has cwd matching project_dir (macOS)."""
+    try:
+        result = subprocess.run(
+            ["lsof", "-a", "-d", "cwd", "-Fn"]
+            + [item for pid in pids for item in ("-p", str(pid))],
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        return None
+
+    if result.returncode != 0:
+        return None
+
+    for line in result.stdout.splitlines():
+        if line.startswith("n"):
+            cwd = os.path.realpath(line[1:])
+            if cwd == project_dir:
+                return True
+
+    return False
+
+
+def _check_cwd_proc(pids: list[int], project_dir: str) -> bool | None:
+    """Use /proc to check if any pid has cwd matching project_dir (Linux)."""
+    checked_any = False
+    for pid in pids:
+        try:
+            cwd = os.path.realpath(f"/proc/{pid}/cwd")
+            checked_any = True
+            if cwd == project_dir:
+                return True
+        except (OSError, PermissionError):
+            continue
+
+    return False if checked_any else None
 
 
 # --- Subprocess functions ---
@@ -961,6 +1047,14 @@ def main(issue=None, max_issues=1, require_design=False):
     global cfg
     if cfg is None:
         cfg = load_config()
+
+    session_detected = detect_active_claude_session()
+    if session_detected is True:
+        print(
+            "Active Claude Code session detected in this directory.\n"
+            "Close it, or move the Claude Code session to a parent folder."
+        )
+        return
 
     if not acquire_lock():
         print("Another implementation is running. Exiting.")

--- a/tests/test_implement_issue.py
+++ b/tests/test_implement_issue.py
@@ -19,6 +19,7 @@ from autoloop.implement_issue import (
     design_gate,
     design_issue,
     design_required,
+    detect_active_claude_session,
     detect_issue_type,
     ensure_clean_main,
     get_issue_by_number,
@@ -1274,3 +1275,157 @@ def test_empty_branch_diagnostic_content():
     assert "Missing .claude/settings.json permissions" in EMPTY_BRANCH_DIAGNOSTIC
     assert "active Claude Code session" in EMPTY_BRANCH_DIAGNOSTIC
     assert "inner claude invocation failed to start" in EMPTY_BRANCH_DIAGNOSTIC
+
+
+# --- detect_active_claude_session tests ---
+
+
+def test_detect_active_claude_session_returns_none_when_pgrep_unavailable(monkeypatch):
+    """Detection is inconclusive when pgrep is not installed."""
+
+    def fake_run(cmd, **kwargs):
+        if cmd[0] == "pgrep":
+            raise FileNotFoundError("pgrep not found")
+        return type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    monkeypatch.setattr(implement_issue.subprocess, "run", fake_run)
+    result = detect_active_claude_session("/some/project")
+    assert result is None
+
+
+def test_detect_active_claude_session_returns_false_when_no_claude_processes(monkeypatch):
+    """No claude processes running means no session detected."""
+
+    def fake_run(cmd, **kwargs):
+        if cmd[0] == "pgrep":
+            return type("R", (), {"returncode": 1, "stdout": "", "stderr": ""})()
+        return type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    monkeypatch.setattr(implement_issue.subprocess, "run", fake_run)
+    result = detect_active_claude_session("/some/project")
+    assert result is False
+
+
+def test_detect_active_claude_session_returns_true_when_session_in_same_dir(monkeypatch):
+    """Detects a claude session when its cwd matches the project directory."""
+    monkeypatch.setattr(implement_issue.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(implement_issue.os.path, "realpath", lambda p: p)
+
+    def fake_run(cmd, **kwargs):
+        if cmd[0] == "pgrep":
+            return type("R", (), {"returncode": 0, "stdout": "12345 claude\n", "stderr": ""})()
+        if cmd[0] == "lsof":
+            return type(
+                "R", (), {"returncode": 0, "stdout": "p12345\nn/my/project\n", "stderr": ""}
+            )()
+        return type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    monkeypatch.setattr(implement_issue.subprocess, "run", fake_run)
+    result = detect_active_claude_session("/my/project")
+    assert result is True
+
+
+def test_detect_active_claude_session_returns_false_when_session_in_other_dir(monkeypatch):
+    """Claude running in a different directory does not trigger detection."""
+    monkeypatch.setattr(implement_issue.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(implement_issue.os.path, "realpath", lambda p: p)
+
+    def fake_run(cmd, **kwargs):
+        if cmd[0] == "pgrep":
+            return type("R", (), {"returncode": 0, "stdout": "12345 claude\n", "stderr": ""})()
+        if cmd[0] == "lsof":
+            return type(
+                "R", (), {"returncode": 0, "stdout": "p12345\nn/other/dir\n", "stderr": ""}
+            )()
+        return type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    monkeypatch.setattr(implement_issue.subprocess, "run", fake_run)
+    result = detect_active_claude_session("/my/project")
+    assert result is False
+
+
+def test_detect_active_claude_session_ignores_headless_processes(monkeypatch):
+    """Processes with --dangerously-skip-permissions are headless autoloop calls."""
+    monkeypatch.setattr(implement_issue.os.path, "realpath", lambda p: p)
+
+    def fake_run(cmd, **kwargs):
+        if cmd[0] == "pgrep":
+            return type(
+                "R",
+                (),
+                {
+                    "returncode": 0,
+                    "stdout": "12345 claude --dangerously-skip-permissions -p prompt\n",
+                    "stderr": "",
+                },
+            )()
+        return type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    monkeypatch.setattr(implement_issue.subprocess, "run", fake_run)
+    result = detect_active_claude_session("/my/project")
+    assert result is False
+
+
+def test_detect_active_claude_session_returns_none_when_lsof_unavailable(monkeypatch):
+    """Inconclusive when lsof is not available on macOS."""
+    monkeypatch.setattr(implement_issue.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(implement_issue.os.path, "realpath", lambda p: p)
+
+    def fake_run(cmd, **kwargs):
+        if cmd[0] == "pgrep":
+            return type("R", (), {"returncode": 0, "stdout": "12345 claude\n", "stderr": ""})()
+        if cmd[0] == "lsof":
+            raise FileNotFoundError("lsof not found")
+        return type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    monkeypatch.setattr(implement_issue.subprocess, "run", fake_run)
+    result = detect_active_claude_session("/my/project")
+    assert result is None
+
+
+def test_detect_active_claude_session_linux_proc(monkeypatch, tmp_path):
+    """Linux path uses /proc/<pid>/cwd to resolve working directory."""
+    monkeypatch.setattr(implement_issue.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(
+        implement_issue.os.path, "realpath", lambda p: "/my/project" if "proc" in p else p
+    )
+
+    def fake_run(cmd, **kwargs):
+        if cmd[0] == "pgrep":
+            return type("R", (), {"returncode": 0, "stdout": "12345 claude\n", "stderr": ""})()
+        return type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    monkeypatch.setattr(implement_issue.subprocess, "run", fake_run)
+    result = detect_active_claude_session("/my/project")
+    assert result is True
+
+
+def test_main_aborts_when_active_session_detected(monkeypatch, tmp_path, capsys):
+    """main() aborts immediately when an active Claude session is detected."""
+    lock_path = tmp_path / ".autoloop.lock"
+    monkeypatch.setattr(implement_issue, "LOCKFILE", lock_path)
+    monkeypatch.setattr(implement_issue, "load_config", lambda path=None: _test_cfg())
+    monkeypatch.setattr(implement_issue, "detect_active_claude_session", lambda: True)
+
+    implement_issue.cfg = None
+    implement_issue.main()
+    out = capsys.readouterr().out
+    assert "Active Claude Code session detected" in out
+    assert not lock_path.exists()
+
+
+def test_main_proceeds_when_session_detection_inconclusive(monkeypatch, tmp_path, capsys):
+    """main() proceeds normally when detection returns None (inconclusive)."""
+    lock_path = tmp_path / ".autoloop.lock"
+    monkeypatch.setattr(implement_issue, "LOCKFILE", lock_path)
+    monkeypatch.setattr(implement_issue, "load_config", lambda path=None: _test_cfg())
+    monkeypatch.setattr(implement_issue, "detect_active_claude_session", lambda: None)
+    monkeypatch.setattr(implement_issue, "get_top_ready_issue", lambda: None)
+    monkeypatch.setattr(implement_issue, "cleanup_merged_labels", lambda: None)
+    monkeypatch.setattr(implement_issue, "unblock_ready_issues", lambda: None)
+
+    implement_issue.cfg = None
+    implement_issue.main()
+    out = capsys.readouterr().out
+    assert "Active Claude Code session" not in out
+    assert "No more ready issues." in out


### PR DESCRIPTION
Closes #25

## Summary
fix: detect active Claude Code session and fail fast instead of producing empty branch

## Test Plan
- `uv run pytest` — all tests pass
- `uv run ruff check && uv run ruff format --check` — clean

## AutoLoop Run Stats
- Attempts: 1/3
- Duration: 137s
- Input tokens: 56
- Output tokens: 6,107
- Cost: $0.90

Automated implementation by AutoLoop.