### PR TITLE
feat: docs: add platform support section, mode framing, and local- (#27)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,23 @@
 
 Config-driven AI pipeline that triages GitHub issues, implements them via Claude, and opens PRs — all from a single config file.
 
+## Platform Support
+
+- **macOS** — fully supported (local mode)
+- **Linux** — fully supported (local + unattended/VPS mode)
+- **Windows** — not supported
+
+## How It Works
+
+| | Local mode | Unattended mode |
+|---|---|---|
+| Where | Your machine | VPS / remote server |
+| Trigger | You run the command | systemd timer / cron |
+| Gate | You review + merge PRs | Same — you're still the human gate |
+| Best for | Evaluating autoloop, small projects | Trusted repos, overnight batch runs |
+
+Most users start local. Graduate to unattended when you trust it.
+
 ## Installation
 
 ### As a CLI tool (recommended)
@@ -56,7 +73,7 @@ Contributions are currently limited to collaborators. A public issue board for i
 - **Claude Code CLI (`claude`)** — [install](https://docs.anthropic.com/en/docs/claude-code/overview) (requires Claude Max or Pro subscription)
 - A GitHub repo with a test command (`pytest`, `npm test`, `make test`, etc.)
 
-## Quick Start
+## Quick Start (Local Mode)
 
 ### 1. Initialize your repo
 
@@ -82,6 +99,13 @@ git add autoloop.toml .github/workflows/autoloop-cleanup.yml .gitignore
 git commit -m "feat: add autoloop pipeline"
 git push
 ```
+
+### Local Mode Notes
+
+- `autoloop init` scaffolds the required `.claude/settings.json` permissions.
+  If you skipped init, create one manually (see template).
+- Do not run `autoloop implement` while a Claude Code session is open in the
+  same project directory. Close it or move the session to a parent folder.
 
 ### 2. Configure
 
@@ -206,6 +230,8 @@ The `**File:**` section is optional — include it if you know which files need 
 Each section becomes one issue. Triage then handles decomposition and dependency ordering if any issue is too large.
 
 ## Running Unattended
+
+Once you trust the pipeline, automate it with timers on a Linux VPS.
 
 ### With systemd timers (Linux VPS)
 

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = (REPO_ROOT / "README.md").read_text()
+
+
+class TestPlatformSupport:
+    def test_section_exists(self):
+        assert "## Platform Support" in README
+
+    def test_macos_listed(self):
+        assert "**macOS**" in README
+
+    def test_linux_listed(self):
+        assert "**Linux**" in README
+
+    def test_windows_unsupported(self):
+        assert "**Windows** — not supported" in README
+
+
+class TestModeFraming:
+    def test_section_before_quick_start(self):
+        how_idx = README.index("## How It Works")
+        qs_idx = README.index("## Quick Start")
+        assert how_idx < qs_idx
+
+    def test_table_has_local_and_unattended(self):
+        assert "Local mode" in README
+        assert "Unattended mode" in README
+
+    def test_table_rows(self):
+        assert "| Where |" in README
+        assert "| Trigger |" in README
+        assert "| Gate |" in README
+        assert "| Best for |" in README
+
+
+class TestQuickStartLocalMode:
+    def test_labeled_as_local_mode(self):
+        assert "## Quick Start (Local Mode)" in README
+
+    def test_local_mode_notes_exist(self):
+        assert "### Local Mode Notes" in README
+
+    def test_settings_json_note(self):
+        assert "`.claude/settings.json`" in README
+
+    def test_concurrent_session_warning(self):
+        assert "Do not run `autoloop implement` while a Claude Code session is open" in README
+
+
+class TestRunningUnattended:
+    def test_intro_line(self):
+        assert "Once you trust the pipeline, automate it with timers on a Linux VPS." in README
+
+    def test_systemd_content_preserved(self):
+        assert "### With systemd timers (Linux VPS)" in README
+
+    def test_mobile_workflow_preserved(self):
+        assert "### Mobile workflow" in README


### PR DESCRIPTION
Closes #27

## Summary
docs: add platform support section, mode framing, and local-mode notes

## Test Plan
- `uv run pytest` — all tests pass
- `uv run ruff check && uv run ruff format --check` — clean

## AutoLoop Run Stats
- Attempts: 2/3
- Duration: 129s
- Input tokens: 4,810
- Output tokens: 3,928
- Cost: $0.66

Automated implementation by AutoLoop.