### PR TITLE
feat: fix: validate_decomposition clears all depends_on references (#30)

### DIFF
--- a/src/autoloop/triage_issues.py
+++ b/src/autoloop/triage_issues.py
@@ -239,13 +239,16 @@ def _merge_steps(a: dict, b: dict) -> dict:
     why_a = a.get("why_first") or a.get("why_after", "")
     why_b = b.get("why_first") or b.get("why_after", "")
     why = "; ".join(filter(None, [why_a, why_b]))
+    merged_deps = list(set(a.get("depends_on", [])) | set(b.get("depends_on", [])))
+    original_orders = a.get("_original_orders", set()) | b.get("_original_orders", set())
     return {
         "order": min(a.get("order", 1), b.get("order", 1)),
         "title": a["title"] + " + " + b["title"],
         "points": points,
-        "depends_on": [],
+        "depends_on": merged_deps,
         "files": merged_files,
         "why_after": why,
+        "_original_orders": original_orders,
     }
 
 
@@ -255,6 +258,10 @@ def validate_decomposition(decomposition: list[dict], max_sub_issues: int = 12) 
         return list(decomposition)
 
     steps = [dict(s) for s in decomposition]
+
+    # Tag each step with its original order(s) for dependency remapping
+    for s in steps:
+        s.setdefault("_original_orders", {s.get("order", 0)})
 
     # Pass 1: Merge steps that share any file
     changed = True
@@ -297,9 +304,22 @@ def validate_decomposition(decomposition: list[dict], max_sub_issues: int = 12) 
         steps[neighbor] = _merge_steps(steps[neighbor], steps[min_idx])
         del steps[min_idx]
 
+    # Build mapping: original order -> new step index
+    order_mapping: dict[int, int] = {}
+    for i, step in enumerate(steps, 1):
+        for orig in step.get("_original_orders", set()):
+            order_mapping[orig] = i
+
+    # Renumber and remap depends_on
     for i, step in enumerate(steps, 1):
         step["order"] = i
-        step["depends_on"] = []
+        remapped = set()
+        for dep in step.get("depends_on", []):
+            new_idx = order_mapping.get(dep)
+            if new_idx and new_idx != i:
+                remapped.add(new_idx)
+        step["depends_on"] = sorted(remapped)
+        step.pop("_original_orders", None)
 
     return steps
 

--- a/tests/test_triage_issues.py
+++ b/tests/test_triage_issues.py
@@ -686,7 +686,7 @@ def test_validate_decomposition_renumbers_orders():
     assert result[0]["order"] == 1
     assert result[1]["order"] == 2
     assert result[0]["depends_on"] == []
-    assert result[1]["depends_on"] == []
+    assert result[1]["depends_on"] == [1]
 
 
 def test_validate_decomposition_already_valid():
@@ -710,6 +710,99 @@ def test_validate_decomposition_transitive_file_merge():
     result = validate_decomposition(steps)
     assert len(result) == 1
     assert set(result[0]["files"]) == {"x.py", "y.py", "z.py"}
+
+
+def test_validate_decomposition_remaps_deps_after_merge():
+    """Dependencies should be remapped to the absorbing step's new index."""
+    steps = [
+        {"order": 1, "title": "Install packages", "points": 1, "files": ["setup.py"]},
+        {"order": 2, "title": "Configure deps", "points": 1, "files": ["setup.py"]},
+        {
+            "order": 3,
+            "title": "Add endpoint",
+            "points": 3,
+            "files": ["src/api.py"],
+            "depends_on": [2],
+        },
+    ]
+    result = validate_decomposition(steps)
+    assert len(result) == 2
+    api_step = [s for s in result if "src/api.py" in s.get("files", [])][0]
+    setup_step = [s for s in result if "setup.py" in s.get("files", [])][0]
+    assert setup_step["order"] in api_step["depends_on"]
+
+
+def test_validate_decomposition_drops_self_references():
+    """A step should not depend on itself after a merge."""
+    steps = [
+        {"order": 1, "title": "Base model", "points": 1, "files": ["src/model.py"]},
+        {
+            "order": 2,
+            "title": "Model validation",
+            "points": 1,
+            "files": ["src/model.py"],
+            "depends_on": [1],
+        },
+        {"order": 3, "title": "API layer", "points": 3, "files": ["src/api.py"], "depends_on": [2]},
+    ]
+    result = validate_decomposition(steps)
+    for step in result:
+        assert step["order"] not in step["depends_on"]
+
+
+def test_validate_decomposition_preserves_chain():
+    """A dependency chain (1 -> 2 -> 3) with no merges should be preserved."""
+    steps = [
+        {
+            "order": 1,
+            "title": "Schema migration",
+            "points": 3,
+            "files": ["db/schema.py"],
+            "depends_on": [],
+        },
+        {
+            "order": 2,
+            "title": "Data migration",
+            "points": 3,
+            "files": ["db/migrate.py"],
+            "depends_on": [1],
+        },
+        {
+            "order": 3,
+            "title": "API update",
+            "points": 3,
+            "files": ["src/api.py"],
+            "depends_on": [2],
+        },
+    ]
+    result = validate_decomposition(steps)
+    assert len(result) == 3
+    assert result[0]["depends_on"] == []
+    assert result[1]["depends_on"] == [1]
+    assert result[2]["depends_on"] == [2]
+
+
+def test_validate_decomposition_remaps_multiple_deps():
+    """A step depending on multiple others should have all remapped correctly."""
+    steps = [
+        {"order": 1, "title": "Step A", "points": 3, "files": ["a.py"], "depends_on": []},
+        {"order": 2, "title": "Step B", "points": 3, "files": ["b.py"], "depends_on": []},
+        {"order": 3, "title": "Step C", "points": 3, "files": ["c.py"], "depends_on": [1, 2]},
+    ]
+    result = validate_decomposition(steps)
+    assert len(result) == 3
+    assert result[2]["depends_on"] == [1, 2]
+
+
+def test_validate_decomposition_no_internal_metadata_leak():
+    """The _original_orders tracking field should not appear in the output."""
+    steps = [
+        {"order": 1, "title": "A", "points": 3, "files": ["a.py"], "depends_on": []},
+        {"order": 2, "title": "B", "points": 3, "files": ["b.py"], "depends_on": [1]},
+    ]
+    result = validate_decomposition(steps)
+    for step in result:
+        assert "_original_orders" not in step
 
 
 def test_validate_decomposition_regression_20_criteria():


### PR DESCRIPTION
Closes #30

## Summary
fix: validate_decomposition clears all depends_on references instead of remapping them

## Test Plan
- `uv run pytest` — all tests pass
- `uv run ruff check && uv run ruff format --check` — clean

## AutoLoop Run Stats
- Attempts: 1/3
- Duration: 161s
- Input tokens: 15
- Output tokens: 6,180
- Cost: $0.94

Automated implementation by AutoLoop.