### PR TITLE
feat: fix: init scaffolds .claude/settings.json with invalid colon (#33)

### DIFF
--- a/src/autoloop/init.py
+++ b/src/autoloop/init.py
@@ -204,14 +204,14 @@ BASE_ALLOWLIST = [
     "Edit",
     "Write",
     "Bash(git status)",
-    "Bash(git add:*)",
-    "Bash(git commit:*)",
-    "Bash(git checkout:*)",
-    "Bash(git branch:*)",
-    "Bash(git push:*)",
-    "Bash(git diff:*)",
-    "Bash(git log:*)",
-    "Bash(gh:*)",
+    "Bash(git add *)",
+    "Bash(git commit *)",
+    "Bash(git checkout *)",
+    "Bash(git branch *)",
+    "Bash(git push *)",
+    "Bash(git diff *)",
+    "Bash(git log *)",
+    "Bash(gh *)",
 ]
 
 DENY_LIST = [

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -68,9 +68,9 @@ class TestBuildSettingsAllowlist:
         assert "Edit" in allow
         assert "Write" in allow
         assert "Bash(git status)" in allow
-        assert "Bash(git add:*)" in allow
-        assert "Bash(git commit:*)" in allow
-        assert "Bash(gh:*)" in allow
+        assert "Bash(git add *)" in allow
+        assert "Bash(git commit *)" in allow
+        assert "Bash(gh *)" in allow
 
     def test_deny_list_present(self):
         settings = build_settings_allowlist("pytest")


### PR DESCRIPTION
Closes #33

## Summary
fix: init scaffolds .claude/settings.json with invalid colon syntax in Bash permissions

## Test Plan
- `uv run pytest` — all tests pass
- `uv run ruff check && uv run ruff format --check` — clean

## AutoLoop Run Stats
- Attempts: 1/3
- Duration: 56s
- Input tokens: 8
- Output tokens: 1,424
- Cost: $0.24

Automated implementation by AutoLoop.