### PR TITLE
feat: feat: add test_pattern config field and replace hardcoded ch (#36)

### DIFF
--- a/src/autoloop/config.py
+++ b/src/autoloop/config.py
@@ -29,6 +29,7 @@ class AutoLoopConfig:
     spec_truncation: int = 4000
     verify_cmd: str = "uv run pytest"
     lint_command: str = "uv run ruff check && uv run ruff format --check"
+    test_pattern: str = "tests/*.py"
     timer_prefix: str = "autoloop"
     protected_paths: list[str] = field(default_factory=lambda: ["autoloop/"])
     triage_labels: list[str] = field(
@@ -77,6 +78,7 @@ def load_config(path: Path | None = None) -> AutoLoopConfig:
         "verify_cmd",
         "lint_command",
         "timer_prefix",
+        "test_pattern",
     ):
         if key in data:
             setattr(config, key, data[key])

--- a/src/autoloop/implement_issue.py
+++ b/src/autoloop/implement_issue.py
@@ -6,6 +6,7 @@ via load_config().
 
 from __future__ import annotations
 
+import fnmatch
 import json
 import logging
 import os
@@ -105,6 +106,7 @@ def collect_verification_errors(
     lint_rc: int,
     fmt_rc: int,
     changed_files: list[str],
+    test_pattern: str = "tests/*.py",
 ) -> list[str]:
     """Build error list from verification subprocess results."""
     errors = []
@@ -114,9 +116,10 @@ def collect_verification_errors(
         errors.append(f"Tests failed:\n{test_out[-500:]}")
     if lint_rc != 0 or fmt_rc != 0:
         errors.append("Lint or format check failed")
-    test_files = [f for f in changed_files if f.startswith("tests/") and f.endswith(".py")]
-    if not test_files:
-        errors.append("No test files were added or modified")
+    if test_pattern:
+        test_files = [f for f in changed_files if fnmatch.fnmatch(f, test_pattern)]
+        if not test_files:
+            errors.append("No test files were added or modified")
     return errors
 
 
@@ -621,6 +624,7 @@ def verify_implementation(branch: str) -> tuple[bool, str]:
         lint_rc=lint.returncode,
         fmt_rc=fmt.returncode,
         changed_files=changed,
+        test_pattern=cfg.test_pattern,
     )
     if errors:
         return False, "\n".join(errors)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -162,6 +162,39 @@ def test_touches_protected_path_multiple_protected():
     )
 
 
+def test_test_pattern_default():
+    config = AutoLoopConfig()
+    assert config.test_pattern == "tests/*.py"
+
+
+def test_test_pattern_loaded_from_toml(tmp_path, monkeypatch):
+    for var in (
+        "AUTOLOOP_TRIAGE_MODEL",
+        "AUTOLOOP_IMPL_MODEL",
+        "AUTOLOOP_TIMEOUT",
+        "AUTOLOOP_REVIEWER",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    toml_path = tmp_path / "autoloop.toml"
+    toml_path.write_text('test_pattern = "src/**/*.test.ts"\n')
+    config = load_config(toml_path)
+    assert config.test_pattern == "src/**/*.test.ts"
+
+
+def test_test_pattern_empty_from_toml(tmp_path, monkeypatch):
+    for var in (
+        "AUTOLOOP_TRIAGE_MODEL",
+        "AUTOLOOP_IMPL_MODEL",
+        "AUTOLOOP_TIMEOUT",
+        "AUTOLOOP_REVIEWER",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    toml_path = tmp_path / "autoloop.toml"
+    toml_path.write_text('test_pattern = ""\n')
+    config = load_config(toml_path)
+    assert config.test_pattern == ""
+
+
 def test_protected_paths_default():
     config = AutoLoopConfig()
     assert config.protected_paths == ["autoloop/"]

--- a/tests/test_implement_issue.py
+++ b/tests/test_implement_issue.py
@@ -209,6 +209,45 @@ def test_verification_multiple_errors():
     assert len(errors) == 4
 
 
+def test_verification_default_pattern_matches_tests_py():
+    errors = collect_verification_errors(
+        ahead_count="1",
+        test_rc=0,
+        test_out="",
+        lint_rc=0,
+        fmt_rc=0,
+        changed_files=["src/app.py", "tests/test_foo.py"],
+        test_pattern="tests/*.py",
+    )
+    assert errors == []
+
+
+def test_verification_custom_pattern_matches():
+    errors = collect_verification_errors(
+        ahead_count="1",
+        test_rc=0,
+        test_out="",
+        lint_rc=0,
+        fmt_rc=0,
+        changed_files=["src/components/foo.test.ts", "src/app.ts"],
+        test_pattern="src/**/*.test.ts",
+    )
+    assert errors == []
+
+
+def test_verification_empty_pattern_skips_check():
+    errors = collect_verification_errors(
+        ahead_count="1",
+        test_rc=0,
+        test_out="",
+        lint_rc=0,
+        fmt_rc=0,
+        changed_files=["src/app.py"],
+        test_pattern="",
+    )
+    assert errors == []
+
+
 # --- Config-driven tests: build_pr_body uses cfg ---
 
 


### PR DESCRIPTION
Closes #36

## Summary
feat: add test_pattern config field and replace hardcoded check with glob matching in verify step

## Test Plan
- `uv run pytest` — all tests pass
- `uv run ruff check && uv run ruff format --check` — clean

## AutoLoop Run Stats
- Attempts: 1/3
- Duration: 168s
- Input tokens: 20,183
- Output tokens: 7,048
- Cost: $1.03

Automated implementation by AutoLoop.