### PR TITLE
feat: fix: default lint_command to empty string instead of hardcod (#43)

### DIFF
--- a/src/autoloop/config.py
+++ b/src/autoloop/config.py
@@ -28,7 +28,7 @@ class AutoLoopConfig:
     error_truncation: int = 2000
     spec_truncation: int = 4000
     verify_cmd: str = "uv run pytest"
-    lint_command: str = "uv run ruff check && uv run ruff format --check"
+    lint_command: str = ""
     test_pattern: str = "tests/*.py"
     timer_prefix: str = "autoloop"
     protected_paths: list[str] = field(default_factory=lambda: ["autoloop/"])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -60,7 +60,7 @@ def test_partial_toml_keeps_defaults(tmp_path, monkeypatch):
     assert config.impl_model == "claude-opus-4-6[1m]"
     assert config.impl_timeout == 900
     assert config.verify_cmd == "uv run pytest"
-    assert config.lint_command == "uv run ruff check && uv run ruff format --check"
+    assert config.lint_command == ""
     assert config.max_story_points == 2
     assert len(config.triage_labels) == 6
 
@@ -160,6 +160,27 @@ def test_touches_protected_path_multiple_protected():
         touches_protected_path(["autoloop.toml", "src/main.py"], ["autoloop/", "autoloop.toml"])
         is True
     )
+
+
+def test_lint_command_defaults_to_empty():
+    config = AutoLoopConfig()
+    assert config.lint_command == ""
+
+
+def test_lint_command_loaded_from_toml(autoloop_toml, monkeypatch):
+    for var in (
+        "AUTOLOOP_TRIAGE_MODEL",
+        "AUTOLOOP_IMPL_MODEL",
+        "AUTOLOOP_TIMEOUT",
+        "AUTOLOOP_REVIEWER",
+        "AUTOLOOP_TRIAGE_TIMEOUT",
+        "AUTOLOOP_TEST_TIMEOUT",
+        "AUTOLOOP_MAX_RETRIES",
+        "AUTOLOOP_REPO",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    config = load_config(autoloop_toml)
+    assert config.lint_command == "echo lint"
 
 
 def test_test_pattern_default():


### PR DESCRIPTION
Closes #43

## Summary
fix: default lint_command to empty string instead of hardcoded ruff

## Test Plan
- `uv run pytest` — all tests pass
- `uv run ruff check && uv run ruff format --check` — clean

## AutoLoop Run Stats
- Attempts: 1/3
- Duration: 56s
- Input tokens: 6
- Output tokens: 1,391
- Cost: $0.31

Automated implementation by AutoLoop.