### PR TITLE
feat: fix: implementation prompt uses Python-specific instructions (#45)

### DIFF
--- a/src/autoloop/implement_issue.py
+++ b/src/autoloop/implement_issue.py
@@ -84,8 +84,10 @@ def build_pr_body(
         f"{issue['title']}\n\n"
         f"## Test Plan\n"
         f"- `{cfg.verify_cmd}` — all tests pass\n"
-        f"- `uv run ruff check && uv run ruff format --check` — clean\n\n"
     )
+    if cfg.lint_command:
+        body += f"- `{cfg.lint_command}` — clean\n"
+    body += "\n"
     if attempts > 0:
         body += (
             f"## AutoLoop Run Stats\n"
@@ -426,7 +428,7 @@ def build_implementation_prompt(issue: dict) -> str:
             metric_targets,
         )
 
-    return (
+    prompt = (
         f"## Task\n\n"
         f"Implement GitHub issue #{issue['number']}: {issue['title']}\n\n"
         f"## Issue Details\n\n{full_context}\n\n"
@@ -434,11 +436,21 @@ def build_implementation_prompt(issue: dict) -> str:
         f"## Implementation Checklist\n\n"
         f"1. Read the files listed in 'Files to Modify'\n"
         f"2. Implement the changes described in the issue\n"
-        f"3. Write comprehensive unit tests for every new/changed function\n"
-        f"4. Run `{cfg.verify_cmd}` — all tests must pass\n"
-        f"5. Run `uv run ruff check && uv run ruff format` — must be clean\n"
-        f"6. If README.md needs updating (new tools, commands), update it\n"
-        f"7. Stage and commit:\n"
+    )
+
+    step = 3
+    if cfg.test_pattern:
+        prompt += f"{step}. Write comprehensive unit tests for every new/changed function\n"
+        step += 1
+    prompt += f"{step}. Run `{cfg.verify_cmd}` — all tests must pass\n"
+    step += 1
+    if cfg.lint_command:
+        prompt += f"{step}. Run `{cfg.lint_command}` — must be clean\n"
+        step += 1
+    prompt += f"{step}. If README.md needs updating (new tools, commands), update it\n"
+    step += 1
+    prompt += (
+        f"{step}. Stage and commit:\n"
         f"   `git add <specific files>`\n"
         f"   `git commit -m '<type>: <description> (#{issue['number']})'\n"
         f"   Types: fix (bugs), feat (features), refactor\n"
@@ -447,9 +459,20 @@ def build_implementation_prompt(issue: dict) -> str:
         f"- Never use real person or company names in test data\n"
         f"- Follow existing code patterns in this repo\n"
         f"- Do not add features beyond what the issue asks for\n"
-        f"- Do not skip tests or lint\n"
-        f"- Do not run git push\n"
     )
+    if cfg.test_pattern or cfg.lint_command:
+        skippable = " or ".join(
+            part
+            for part in (
+                "tests" if cfg.test_pattern else "",
+                "lint" if cfg.lint_command else "",
+            )
+            if part
+        )
+        prompt += f"- Do not skip {skippable}\n"
+    prompt += "- Do not run git push\n"
+
+    return prompt
 
 
 DESIGN_PROMPT = (

--- a/tests/test_implement_issue.py
+++ b/tests/test_implement_issue.py
@@ -285,6 +285,28 @@ def test_build_pr_body_no_stats_when_zero_calls(monkeypatch):
     assert "AutoLoop Run Stats" not in body
 
 
+def test_build_pr_body_uses_cfg_lint_command(monkeypatch):
+    monkeypatch.setattr(
+        implement_issue, "cfg", _test_cfg(lint_command="eslint . && prettier --check .")
+    )
+
+    issue = {"number": 42, "title": "Add flag"}
+    body = build_pr_body(issue)
+
+    assert "`eslint . && prettier --check .`" in body
+    assert "ruff" not in body
+
+
+def test_build_pr_body_omits_lint_line_when_lint_command_empty(monkeypatch):
+    monkeypatch.setattr(implement_issue, "cfg", _test_cfg(lint_command=""))
+
+    issue = {"number": 42, "title": "Add flag"}
+    body = build_pr_body(issue)
+
+    assert "ruff" not in body
+    assert "lint" not in body.lower().split("autoloop")[0]
+
+
 # --- Config-driven tests: subprocess calls use cfg.repo ---
 
 
@@ -624,6 +646,131 @@ def test_build_implementation_prompt_references_cfg_verify_cmd(monkeypatch, tmp_
 
     assert "`npm test`" in prompt
     assert "uv run pytest" not in prompt
+
+
+def test_build_implementation_prompt_uses_cfg_lint_command(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        implement_issue,
+        "cfg",
+        _test_cfg(lint_command="eslint . && prettier --check .", repo="my-org/my-repo"),
+    )
+    claude_md = tmp_path / "CLAUDE.md"
+    claude_md.write_text("# Project\nTest project")
+    monkeypatch.setattr(implement_issue, "REPO_DIR", tmp_path)
+
+    def fake_run(cmd, **kwargs):
+        return type("R", (), {"returncode": 1, "stdout": "", "stderr": ""})()
+
+    monkeypatch.setattr(implement_issue.subprocess, "run", fake_run)
+
+    issue = {"number": 1, "title": "Test", "body": "details"}
+    prompt = implement_issue.build_implementation_prompt(issue)
+
+    assert "`eslint . && prettier --check .`" in prompt
+    assert "ruff" not in prompt
+
+
+def test_build_implementation_prompt_omits_lint_when_empty(monkeypatch, tmp_path):
+    monkeypatch.setattr(implement_issue, "cfg", _test_cfg(lint_command="", repo="my-org/my-repo"))
+    claude_md = tmp_path / "CLAUDE.md"
+    claude_md.write_text("# Project\nTest project")
+    monkeypatch.setattr(implement_issue, "REPO_DIR", tmp_path)
+
+    def fake_run(cmd, **kwargs):
+        return type("R", (), {"returncode": 1, "stdout": "", "stderr": ""})()
+
+    monkeypatch.setattr(implement_issue.subprocess, "run", fake_run)
+
+    issue = {"number": 1, "title": "Test", "body": "details"}
+    prompt = implement_issue.build_implementation_prompt(issue)
+
+    assert "ruff" not in prompt
+    assert "lint" not in prompt.lower().split("## rules")[0]
+
+
+def test_build_implementation_prompt_omits_test_step_when_test_pattern_empty(monkeypatch, tmp_path):
+    monkeypatch.setattr(implement_issue, "cfg", _test_cfg(test_pattern="", repo="my-org/my-repo"))
+    claude_md = tmp_path / "CLAUDE.md"
+    claude_md.write_text("# Project\nTest project")
+    monkeypatch.setattr(implement_issue, "REPO_DIR", tmp_path)
+
+    def fake_run(cmd, **kwargs):
+        return type("R", (), {"returncode": 1, "stdout": "", "stderr": ""})()
+
+    monkeypatch.setattr(implement_issue.subprocess, "run", fake_run)
+
+    issue = {"number": 1, "title": "Test issue", "body": "details"}
+    prompt = implement_issue.build_implementation_prompt(issue)
+
+    assert "Write comprehensive unit tests" not in prompt
+    assert "Do not skip tests" not in prompt
+
+
+def test_build_implementation_prompt_includes_test_step_when_test_pattern_set(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(
+        implement_issue,
+        "cfg",
+        _test_cfg(test_pattern="src/**/*.test.ts", lint_command="eslint .", repo="my-org/my-repo"),
+    )
+    claude_md = tmp_path / "CLAUDE.md"
+    claude_md.write_text("# Project\nTest project")
+    monkeypatch.setattr(implement_issue, "REPO_DIR", tmp_path)
+
+    def fake_run(cmd, **kwargs):
+        return type("R", (), {"returncode": 1, "stdout": "", "stderr": ""})()
+
+    monkeypatch.setattr(implement_issue.subprocess, "run", fake_run)
+
+    issue = {"number": 1, "title": "Test issue", "body": "details"}
+    prompt = implement_issue.build_implementation_prompt(issue)
+
+    assert "Write comprehensive unit tests" in prompt
+    assert "Do not skip tests or lint" in prompt
+
+
+def test_build_implementation_prompt_skip_rule_lint_only(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        implement_issue,
+        "cfg",
+        _test_cfg(test_pattern="", lint_command="eslint .", repo="my-org/my-repo"),
+    )
+    claude_md = tmp_path / "CLAUDE.md"
+    claude_md.write_text("# Project\nTest project")
+    monkeypatch.setattr(implement_issue, "REPO_DIR", tmp_path)
+
+    def fake_run(cmd, **kwargs):
+        return type("R", (), {"returncode": 1, "stdout": "", "stderr": ""})()
+
+    monkeypatch.setattr(implement_issue.subprocess, "run", fake_run)
+
+    issue = {"number": 1, "title": "Test issue", "body": "details"}
+    prompt = implement_issue.build_implementation_prompt(issue)
+
+    assert "Do not skip lint" in prompt
+    assert "Do not skip tests" not in prompt
+
+
+def test_build_implementation_prompt_no_skip_rule_when_both_empty(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        implement_issue,
+        "cfg",
+        _test_cfg(test_pattern="", lint_command="", repo="my-org/my-repo"),
+    )
+    claude_md = tmp_path / "CLAUDE.md"
+    claude_md.write_text("# Project\nTest project")
+    monkeypatch.setattr(implement_issue, "REPO_DIR", tmp_path)
+
+    def fake_run(cmd, **kwargs):
+        return type("R", (), {"returncode": 1, "stdout": "", "stderr": ""})()
+
+    monkeypatch.setattr(implement_issue.subprocess, "run", fake_run)
+
+    issue = {"number": 1, "title": "Test issue", "body": "details"}
+    prompt = implement_issue.build_implementation_prompt(issue)
+
+    assert "Do not skip" not in prompt
 
 
 # --- Config-driven tests: review_implementation uses cfg.impl_model ---


### PR DESCRIPTION
Closes #45

## Summary
fix: implementation prompt uses Python-specific instructions regardless of project language

## Test Plan
- `uv run pytest` — all tests pass
- `uv run ruff check && uv run ruff format --check` — clean

## AutoLoop Run Stats
- Attempts: 1/3
- Duration: 245s
- Input tokens: 25
- Output tokens: 8,056
- Cost: $1.38

Automated implementation by AutoLoop.