### PR TITLE
feat: fix: autoloop-cleanup.yml missing checkout step and pinned t (#51)

### DIFF
--- a/.github/workflows/autoloop-cleanup.yml
+++ b/.github/workflows/autoloop-cleanup.yml
@@ -42,12 +42,14 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.13"
       - name: Install autoloop
-        run: pip install git+https://github.com/Sanctum-Origo-Systems/autoloop@v0.1.7
+        run: pip install git+https://github.com/Sanctum-Origo-Systems/autoloop@main
       - name: Auto-close parent issue
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/autoloop/init.py
+++ b/src/autoloop/init.py
@@ -101,34 +101,36 @@ jobs:
             ];
             const body = context.payload.pull_request.body || '';
             const matches = body.match(/Closes #(\\d+)/g) || [];
-            for (const match of matches) {{
+            for (const match of matches) {
               const issueNumber = parseInt(match.replace('Closes #', ''));
-              for (const label of labels) {{
-                try {{
-                  await github.rest.issues.removeLabel({{
+              for (const label of labels) {
+                try {
+                  await github.rest.issues.removeLabel({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     issue_number: issueNumber,
                     name: label
-                  }});
-                }} catch (e) {{}}
-              }}
-            }}
+                  });
+                } catch (e) {}
+              }
+            }
 
   auto-close-parent:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.13"
       - name: Install autoloop
-        run: pip install git+https://github.com/Sanctum-Origo-Systems/autoloop@v{version}
+        run: pip install git+https://github.com/Sanctum-Origo-Systems/autoloop@main
       - name: Auto-close parent issue
         env:
-          GH_TOKEN: ${{{{ secrets.GITHUB_TOKEN }}}}
-        run: autoloop auto-close-parent "${{{{ github.event.pull_request.number }}}}"
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: autoloop auto-close-parent "${{ github.event.pull_request.number }}"
 """
 
 GITIGNORE_ENTRY = "autoloop/run_history.jsonl"
@@ -177,14 +179,12 @@ def write_toml(target: Path, repo: str, reviewer: str, verify_cmd: str) -> None:
 
 
 def write_workflow(target: Path) -> None:
-    from autoloop import __version__
-
     path = target / ".github" / "workflows" / "autoloop-cleanup.yml"
     path.parent.mkdir(parents=True, exist_ok=True)
     if path.exists():
         print("  workflow already exists, skipping (delete to regenerate)")
         return
-    path.write_text(WORKFLOW_TEMPLATE.format(version=__version__))
+    path.write_text(WORKFLOW_TEMPLATE)
     print("  created .github/workflows/autoloop-cleanup.yml")
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -4,11 +4,13 @@ import json
 from unittest.mock import patch
 
 from autoloop.init import (
+    WORKFLOW_TEMPLATE,
     _extract_command_prefixes,
     build_settings_allowlist,
     infer_test_pattern,
     run_init,
     write_claude_settings,
+    write_workflow,
 )
 
 
@@ -274,3 +276,57 @@ class TestWriteTomlTestPattern:
 
         cfg = load_config(tmp_path / "autoloop.toml")
         assert cfg.test_pattern == "src/**/*.test.*"
+
+
+class TestWorkflowTemplate:
+    def test_template_has_checkout_step(self):
+        assert "actions/checkout@v4" in WORKFLOW_TEMPLATE
+
+    def test_template_installs_from_main(self):
+        assert "@main" in WORKFLOW_TEMPLATE
+
+    def test_template_no_pinned_version(self):
+        assert "autoloop@v" not in WORKFLOW_TEMPLATE
+
+    def test_template_no_format_placeholders(self):
+        assert "{version}" not in WORKFLOW_TEMPLATE
+
+
+class TestWriteWorkflow:
+    def test_creates_workflow_file(self, tmp_path, capsys):
+        write_workflow(tmp_path)
+        path = tmp_path / ".github" / "workflows" / "autoloop-cleanup.yml"
+        assert path.exists()
+        out = capsys.readouterr().out
+        assert "created .github/workflows/autoloop-cleanup.yml" in out
+
+    def test_workflow_has_checkout_before_python(self, tmp_path):
+        write_workflow(tmp_path)
+        path = tmp_path / ".github" / "workflows" / "autoloop-cleanup.yml"
+        content = path.read_text()
+        checkout_pos = content.index("actions/checkout@v4")
+        python_pos = content.index("actions/setup-python@v5")
+        assert checkout_pos < python_pos
+
+    def test_workflow_installs_from_main(self, tmp_path):
+        write_workflow(tmp_path)
+        path = tmp_path / ".github" / "workflows" / "autoloop-cleanup.yml"
+        content = path.read_text()
+        assert "autoloop@main" in content
+        assert "autoloop@v" not in content
+
+    def test_workflow_skips_existing(self, tmp_path, capsys):
+        path = tmp_path / ".github" / "workflows" / "autoloop-cleanup.yml"
+        path.parent.mkdir(parents=True)
+        path.write_text("existing")
+        write_workflow(tmp_path)
+        assert path.read_text() == "existing"
+        out = capsys.readouterr().out
+        assert "already exists" in out
+
+    def test_workflow_valid_github_actions_expressions(self, tmp_path):
+        write_workflow(tmp_path)
+        path = tmp_path / ".github" / "workflows" / "autoloop-cleanup.yml"
+        content = path.read_text()
+        assert "${{ secrets.GITHUB_TOKEN }}" in content
+        assert "${{ github.event.pull_request.number }}" in content


### PR DESCRIPTION
Closes #51

## Summary
fix: autoloop-cleanup.yml missing checkout step and pinned to old version

## Test Plan
- `uv run pytest` — all tests pass
- `uv run ruff check && uv run ruff format --check` — clean

## AutoLoop Run Stats
- Attempts: 1/3
- Duration: 228s
- Input tokens: 24
- Output tokens: 8,316
- Cost: $1.06

Automated implementation by AutoLoop.