### PR TITLE
feat: feat: add preflight core logic and CLI subcommand (#46)

### DIFF
--- a/src/autoloop/cli.py
+++ b/src/autoloop/cli.py
@@ -66,6 +66,9 @@ def main():
     )
     acp_parser.add_argument("pr_number", type=int, help="PR number to check")
 
+    # preflight
+    subparsers.add_parser("preflight", help="Run verify and lint commands on the current branch")
+
     # version (also accessible via --version)
     subparsers.add_parser("version", help="Print installed version")
 
@@ -126,6 +129,24 @@ def main():
             print(f"Closed parent issue #{result}")
         else:
             print("No parent issue to close.")
+
+    elif args.command == "preflight":
+        from autoloop.config import load_config
+        from autoloop.preflight import run_preflight
+
+        cfg = load_config()
+        results = run_preflight(cfg)
+        any_failed = False
+        for name, result in results.items():
+            if result["skipped"]:
+                print(f"  {name}: skipped")
+                continue
+            status = "pass" if result["passed"] else "FAIL"
+            print(f"  {name}: {status} ({result['elapsed']:.2f}s)")
+            if not result["passed"]:
+                any_failed = True
+                print(result["output"])
+        sys.exit(1 if any_failed else 0)
 
 
 def _show_status():

--- a/src/autoloop/preflight.py
+++ b/src/autoloop/preflight.py
@@ -1,0 +1,41 @@
+"""Preflight checks: run verify and lint commands, report results."""
+
+from __future__ import annotations
+
+import subprocess
+import time
+
+from autoloop.config import AutoLoopConfig
+
+
+def _run_command(cmd: str) -> dict:
+    """Run a shell command and return result dict with passed, elapsed, output."""
+    start = time.monotonic()
+    result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+    elapsed = time.monotonic() - start
+    output = result.stdout + result.stderr
+    return {
+        "skipped": False,
+        "passed": result.returncode == 0,
+        "elapsed": elapsed,
+        "output": output,
+    }
+
+
+def run_preflight(cfg: AutoLoopConfig) -> dict:
+    """Run preflight checks and return results for each command."""
+    results = {}
+
+    results["verify_cmd"] = _run_command(cfg.verify_cmd)
+
+    if cfg.lint_command:
+        results["lint_command"] = _run_command(cfg.lint_command)
+    else:
+        results["lint_command"] = {
+            "skipped": True,
+            "passed": False,
+            "elapsed": 0.0,
+            "output": "",
+        }
+
+    return results

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -1,0 +1,108 @@
+"""Tests for autoloop preflight command."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+def _cfg(**overrides):
+    defaults = {
+        "verify_cmd": "echo ok",
+        "lint_command": "echo lint-ok",
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _ok(stdout="", stderr="", returncode=0):
+    return type("R", (), {"returncode": returncode, "stdout": stdout, "stderr": stderr})()
+
+
+def test_run_preflight_pass():
+    def fake_run(cmd, **kwargs):
+        return _ok(stdout="all passed\n")
+
+    with patch("autoloop.preflight.subprocess.run", fake_run):
+        from autoloop.preflight import run_preflight
+
+        result = run_preflight(_cfg())
+
+    assert result["verify_cmd"]["passed"] is True
+    assert result["verify_cmd"]["skipped"] is False
+    assert result["verify_cmd"]["elapsed"] >= 0
+    assert result["lint_command"]["passed"] is True
+    assert result["lint_command"]["skipped"] is False
+
+
+def test_run_preflight_verify_fails():
+    def fake_run(cmd, **kwargs):
+        if "echo ok" in cmd:
+            return _ok(returncode=1, stdout="", stderr="FAILED test_x\nTraceback:\n  ...")
+        return _ok()
+
+    with patch("autoloop.preflight.subprocess.run", fake_run):
+        from autoloop.preflight import run_preflight
+
+        result = run_preflight(_cfg())
+
+    assert result["verify_cmd"]["passed"] is False
+    assert "FAILED test_x" in result["verify_cmd"]["output"]
+    assert "Traceback" in result["verify_cmd"]["output"]
+
+
+def test_run_preflight_lint_skipped_when_empty():
+    def fake_run(cmd, **kwargs):
+        return _ok(stdout="ok\n")
+
+    with patch("autoloop.preflight.subprocess.run", fake_run):
+        from autoloop.preflight import run_preflight
+
+        result = run_preflight(_cfg(lint_command=""))
+
+    assert result["lint_command"]["skipped"] is True
+    assert result["verify_cmd"]["passed"] is True
+
+
+def test_run_preflight_lint_skipped_when_none():
+    def fake_run(cmd, **kwargs):
+        return _ok(stdout="ok\n")
+
+    with patch("autoloop.preflight.subprocess.run", fake_run):
+        from autoloop.preflight import run_preflight
+
+        result = run_preflight(_cfg(lint_command=None))
+
+    assert result["lint_command"]["skipped"] is True
+
+
+def test_run_preflight_lint_fails():
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if "lint" in cmd:
+            return _ok(returncode=1, stderr="lint error\n")
+        return _ok(stdout="ok\n")
+
+    with patch("autoloop.preflight.subprocess.run", fake_run):
+        from autoloop.preflight import run_preflight
+
+        result = run_preflight(_cfg())
+
+    assert result["verify_cmd"]["passed"] is True
+    assert result["lint_command"]["passed"] is False
+    assert "lint error" in result["lint_command"]["output"]
+
+
+def test_run_preflight_output_combines_stdout_and_stderr():
+    def fake_run(cmd, **kwargs):
+        return _ok(returncode=1, stdout="stdout line\n", stderr="stderr line\n")
+
+    with patch("autoloop.preflight.subprocess.run", fake_run):
+        from autoloop.preflight import run_preflight
+
+        result = run_preflight(_cfg())
+
+    assert "stdout line" in result["verify_cmd"]["output"]
+    assert "stderr line" in result["verify_cmd"]["output"]


### PR DESCRIPTION
Closes #46

## Summary
feat: add preflight core logic and CLI subcommand

## Test Plan
- `uv run pytest` — all tests pass
- `uv run ruff check && uv run ruff format --check` — clean

## AutoLoop Run Stats
- Attempts: 1/3
- Duration: 149s
- Input tokens: 14
- Output tokens: 3,905
- Cost: $0.66

Automated implementation by AutoLoop.