### PR TITLE
feat: feat: add autoloop_preflight MCP tool (#47)

### DIFF
--- a/src/autoloop/mcp_server.py
+++ b/src/autoloop/mcp_server.py
@@ -130,6 +130,16 @@ def main():
         return f"Started fix-pr for PR #{pr_number}."
 
     @server.tool()
+    def autoloop_preflight(repo_dir: str | None = None) -> str:
+        """Run preflight checks (verify and lint commands) on the current branch.
+
+        Args:
+            repo_dir: Target repository directory. Defaults to server's working directory.
+        """
+        _spawn(["autoloop", "preflight"], cwd=repo_dir)
+        return "Started preflight checks."
+
+    @server.tool()
     def autoloop_status(repo_dir: str | None = None) -> str:
         """Check last run result, active runs, ready issue count, and next scheduled runs.
 

--- a/tests/test_mcp_repo_dir.py
+++ b/tests/test_mcp_repo_dir.py
@@ -147,6 +147,42 @@ def test_triage_cwd_none_when_no_repo_dir(mcp_tools):
     assert captured[0]["kwargs"]["cwd"] is None
 
 
+def test_preflight_passes_cwd(mcp_tools, tmp_path):
+    """autoloop_preflight passes repo_dir as cwd to Popen."""
+    captured = []
+
+    def fake_popen(cmd, **kwargs):
+        captured.append({"cmd": cmd, "kwargs": kwargs})
+
+    with patch("autoloop.mcp_server.subprocess.Popen", fake_popen):
+        result = mcp_tools["autoloop_preflight"](repo_dir=str(tmp_path))
+
+    assert len(captured) == 1
+    assert captured[0]["kwargs"]["cwd"] == str(tmp_path)
+    assert captured[0]["cmd"] == ["autoloop", "preflight"]
+    assert result == "Started preflight checks."
+
+
+def test_preflight_cwd_none_when_no_repo_dir(mcp_tools):
+    """autoloop_preflight passes cwd=None when repo_dir omitted."""
+    captured = []
+
+    def fake_popen(cmd, **kwargs):
+        captured.append({"cmd": cmd, "kwargs": kwargs})
+
+    with patch("autoloop.mcp_server.subprocess.Popen", fake_popen):
+        result = mcp_tools["autoloop_preflight"]()
+
+    assert len(captured) == 1
+    assert captured[0]["kwargs"]["cwd"] is None
+    assert result == "Started preflight checks."
+
+
+def test_preflight_registered(mcp_tools):
+    """autoloop_preflight appears in the MCP server's tool listing."""
+    assert "autoloop_preflight" in mcp_tools
+
+
 def test_fix_pr_passes_cwd(mcp_tools, tmp_path):
     """autoloop_fix_pr passes repo_dir as cwd to Popen."""
     captured = []


### PR DESCRIPTION
Closes #47

## Summary
feat: add autoloop_preflight MCP tool

## Test Plan
- `uv run pytest` — all tests pass
- `uv run ruff check && uv run ruff format --check` — clean

## AutoLoop Run Stats
- Attempts: 1/3
- Duration: 79s
- Input tokens: 11
- Output tokens: 2,247
- Cost: $0.34

Automated implementation by AutoLoop.