### PR TITLE
feat: fix: raise max_story_points default to 3 and include in gene (#57)

### DIFF
--- a/src/autoloop/config.py
+++ b/src/autoloop/config.py
@@ -22,7 +22,7 @@ class AutoLoopConfig:
     test_timeout: int = 120
     pr_reviewer: str = "andywidjaja"
     max_retries: int = 3
-    max_story_points: int = 2
+    max_story_points: int = 3
     tree_truncation: int = 3000
     diff_truncation: int = 8000
     error_truncation: int = 2000

--- a/src/autoloop/init.py
+++ b/src/autoloop/init.py
@@ -47,6 +47,9 @@ pr_reviewer = "{reviewer}"
 verify_cmd = "{verify_cmd}"
 test_pattern = "{test_pattern}"  # glob pattern matching test files — inferred from verify_cmd
 
+# Decomposition threshold — issues above this trigger sub-issue creation
+max_story_points = 3
+
 # Retry / truncation limits
 max_retries = 3
 tree_truncation = 3000

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -61,7 +61,7 @@ def test_partial_toml_keeps_defaults(tmp_path, monkeypatch):
     assert config.impl_timeout == 900
     assert config.verify_cmd == "uv run pytest"
     assert config.lint_command == ""
-    assert config.max_story_points == 2
+    assert config.max_story_points == 3
     assert len(config.triage_labels) == 6
 
 


### PR DESCRIPTION
Closes #57

## Summary
fix: raise max_story_points default to 3 and include in generated toml

## Test Plan
- `uv run pytest` — all tests pass

## AutoLoop Run Stats
- Attempts: 1/3
- Duration: 75s
- Input tokens: 10
- Output tokens: 1,928
- Cost: $0.46

Automated implementation by AutoLoop.