### PR TITLE
feat: fix: skip test-file gate for refactor/migration/docs issues  (#61)

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,7 @@ Example workflow from your phone:
 | `lint_command` | `uv run ruff check && uv run ruff format --check` | Lint check command |
 | `timer_prefix` | `autoloop` | Systemd timer prefix for status detection (use your app name, e.g. `myapp`) |
 | `protected_paths` | `["autoloop/"]` | Paths the bot must never modify |
+| `test_gate_skip_types` | `["refactor", "docs", "chore"]` | Issue types that skip the "must add test files" verification check |
 | `triage_labels` | `["ready", "rejected", ...]` | Labels that indicate an issue has been triaged |
 
 All fields can be overridden by environment variables (e.g. `AUTOLOOP_IMPL_MODEL`, `AUTOLOOP_TIMEOUT`).

--- a/src/autoloop/config.py
+++ b/src/autoloop/config.py
@@ -32,6 +32,7 @@ class AutoLoopConfig:
     test_pattern: str = "tests/*.py"
     timer_prefix: str = "autoloop"
     protected_paths: list[str] = field(default_factory=lambda: ["autoloop/"])
+    test_gate_skip_types: list[str] = field(default_factory=lambda: ["refactor", "docs", "chore"])
     triage_labels: list[str] = field(
         default_factory=lambda: [
             "ready",
@@ -99,6 +100,9 @@ def load_config(path: Path | None = None) -> AutoLoopConfig:
 
     if "protected_paths" in data:
         config.protected_paths = list(data["protected_paths"])
+
+    if "test_gate_skip_types" in data:
+        config.test_gate_skip_types = list(data["test_gate_skip_types"])
 
     if "triage_labels" in data:
         config.triage_labels = list(data["triage_labels"])

--- a/src/autoloop/implement_issue.py
+++ b/src/autoloop/implement_issue.py
@@ -66,6 +66,12 @@ def detect_issue_type(body: str) -> str:
         return "fix"
     if "## type\nrefactor" in body_lower:
         return "refactor"
+    if "## type\nmigration" in body_lower:
+        return "refactor"
+    if "## type\ndocs" in body_lower:
+        return "docs"
+    if "## type\nchore" in body_lower:
+        return "chore"
     return "feat"
 
 
@@ -108,6 +114,8 @@ def collect_verification_errors(
     lint_rc: int,
     changed_files: list[str],
     test_pattern: str = "tests/*.py",
+    issue_type: str = "feat",
+    test_gate_skip_types: list[str] | None = None,
 ) -> list[str]:
     """Build error list from verification subprocess results."""
     errors = []
@@ -117,7 +125,8 @@ def collect_verification_errors(
         errors.append(f"Tests failed:\n{test_out[-500:]}")
     if lint_rc != 0:
         errors.append("Lint or format check failed")
-    if test_pattern:
+    skip_types = test_gate_skip_types if test_gate_skip_types is not None else []
+    if test_pattern and issue_type not in skip_types:
         test_files = [f for f in changed_files if fnmatch.fnmatch(f, test_pattern)]
         if not test_files:
             errors.append("No test files were added or modified")
@@ -603,7 +612,7 @@ def is_branch_empty(branch: str) -> bool:
     return count == "0" or count == ""
 
 
-def verify_implementation(branch: str) -> tuple[bool, str]:
+def verify_implementation(branch: str, issue_body: str = "") -> tuple[bool, str]:
     """Verify the agent actually produced valid work."""
     ahead = subprocess.run(
         ["git", "rev-list", "--count", f"main..{branch}"],
@@ -645,6 +654,8 @@ def verify_implementation(branch: str) -> tuple[bool, str]:
         lint_rc=lint_rc,
         changed_files=changed,
         test_pattern=cfg.test_pattern,
+        issue_type=detect_issue_type(issue_body),
+        test_gate_skip_types=cfg.test_gate_skip_types,
     )
     if errors:
         return False, "\n".join(errors)
@@ -954,7 +965,7 @@ def implement_single_issue(issue: dict, require_design: bool = False) -> bool:
                 empty_branch_failure = True
                 break
 
-            valid, errors = verify_implementation(branch)
+            valid, errors = verify_implementation(branch, issue_body=issue.get("body", ""))
             if not valid:
                 print(f"  Verification failed:\n{errors}")
                 last_errors = errors

--- a/src/autoloop/triage_issues.py
+++ b/src/autoloop/triage_issues.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
 from autoloop.claude_runner import ClaudeResult, run_claude
 from autoloop.config import REPO_DIR
 from autoloop.create_issue import build_issue_body
+from autoloop.implement_issue import detect_issue_type
 
 LOG_FILE = REPO_DIR / "autoloop" / "run_history.jsonl"
 
@@ -620,6 +621,7 @@ def create_sub_issues(
     parent_summary: str = "",
 ) -> list[int]:
     """Create sub-issues from a decomposition and return their numbers."""
+    parent_type = detect_issue_type(parent_summary)
     step_to_issue: dict[int, int] = {}
     created: list[int] = []
     for step in result.get("decomposition", []):
@@ -636,10 +638,16 @@ def create_sub_issues(
             expected = step["title"]
             extra_criteria = ""
 
+        issue_type_label = {
+            "fix": "bug",
+            "refactor": "refactor",
+            "docs": "docs",
+            "chore": "chore",
+        }.get(parent_type, "feature")
         why = step.get("why_first") or step.get("why_after", "")
         body = build_issue_body(
             summary=step["title"],
-            issue_type="feature",
+            issue_type=issue_type_label,
             files="\n".join(step.get("files", [])),
             current_behavior="",
             expected=expected,

--- a/tests/test_implement_issue.py
+++ b/tests/test_implement_issue.py
@@ -130,6 +130,22 @@ def test_detect_issue_type_feature():
     assert detect_issue_type("## Summary\nAdd\n\n## Type\nfeature") == "feat"
 
 
+def test_detect_issue_type_refactor():
+    assert detect_issue_type("## Summary\nClean up\n\n## Type\nrefactor") == "refactor"
+
+
+def test_detect_issue_type_migration():
+    assert detect_issue_type("## Summary\nMigrate to uv\n\n## Type\nmigration") == "refactor"
+
+
+def test_detect_issue_type_docs():
+    assert detect_issue_type("## Summary\nUpdate docs\n\n## Type\ndocs") == "docs"
+
+
+def test_detect_issue_type_chore():
+    assert detect_issue_type("## Summary\nBump deps\n\n## Type\nchore") == "chore"
+
+
 def test_detect_issue_type_default_feat():
     assert detect_issue_type("no type section here") == "feat"
 
@@ -237,6 +253,95 @@ def test_verification_empty_pattern_skips_check():
         test_pattern="",
     )
     assert errors == []
+
+
+def test_verification_refactor_skips_test_gate():
+    errors = collect_verification_errors(
+        ahead_count="1",
+        test_rc=0,
+        test_out="",
+        lint_rc=0,
+        changed_files=["src/app.py"],
+        test_pattern="tests/*.py",
+        issue_type="refactor",
+        test_gate_skip_types=["refactor", "docs", "chore"],
+    )
+    assert errors == []
+
+
+def test_verification_docs_skips_test_gate():
+    errors = collect_verification_errors(
+        ahead_count="1",
+        test_rc=0,
+        test_out="",
+        lint_rc=0,
+        changed_files=["README.md"],
+        test_pattern="tests/*.py",
+        issue_type="docs",
+        test_gate_skip_types=["refactor", "docs", "chore"],
+    )
+    assert errors == []
+
+
+def test_verification_chore_skips_test_gate():
+    errors = collect_verification_errors(
+        ahead_count="1",
+        test_rc=0,
+        test_out="",
+        lint_rc=0,
+        changed_files=["pyproject.toml"],
+        test_pattern="tests/*.py",
+        issue_type="chore",
+        test_gate_skip_types=["refactor", "docs", "chore"],
+    )
+    assert errors == []
+
+
+def test_verification_feat_still_requires_test_files():
+    errors = collect_verification_errors(
+        ahead_count="1",
+        test_rc=0,
+        test_out="",
+        lint_rc=0,
+        changed_files=["src/app.py"],
+        test_pattern="tests/*.py",
+        issue_type="feat",
+        test_gate_skip_types=["refactor", "docs", "chore"],
+    )
+    assert "No test files were added or modified" in errors
+
+
+def test_verification_migration_sub_issue_skips_test_gate():
+    """A migration issue (detected as refactor) with no test changes passes."""
+    body = "## Summary\nMigrate to uv\n\n## Type\nmigration"
+    issue_type = detect_issue_type(body)
+    errors = collect_verification_errors(
+        ahead_count="1",
+        test_rc=0,
+        test_out="",
+        lint_rc=0,
+        changed_files=["pyproject.toml", "uv.lock"],
+        test_pattern="tests/*.py",
+        issue_type=issue_type,
+        test_gate_skip_types=["refactor", "docs", "chore"],
+    )
+    assert errors == []
+
+
+def test_verification_skip_types_still_runs_tests():
+    """Even skip-type issues fail if the test suite itself fails."""
+    errors = collect_verification_errors(
+        ahead_count="1",
+        test_rc=1,
+        test_out="FAILED test_something",
+        lint_rc=0,
+        changed_files=["pyproject.toml"],
+        test_pattern="tests/*.py",
+        issue_type="refactor",
+        test_gate_skip_types=["refactor", "docs", "chore"],
+    )
+    assert any("Tests failed" in e for e in errors)
+    assert "No test files were added or modified" not in errors
 
 
 # --- Config-driven tests: build_pr_body uses cfg ---
@@ -946,7 +1051,9 @@ def test_implement_single_issue_uses_cfg_max_retries(monkeypatch, tmp_path):
     monkeypatch.setattr(implement_issue, "cleanup_branch", lambda branch: None)
     monkeypatch.setattr(implement_issue, "is_branch_empty", lambda branch: False)
     monkeypatch.setattr(
-        implement_issue, "verify_implementation", lambda branch: (False, "Tests failed")
+        implement_issue,
+        "verify_implementation",
+        lambda branch, issue_body="": (False, "Tests failed"),
     )
     monkeypatch.setattr(implement_issue, "post_attempt_failure", lambda n, a, e: None)
 
@@ -975,7 +1082,9 @@ def test_implement_single_issue_returns_false_after_all_retries(monkeypatch, tmp
     monkeypatch.setattr(implement_issue, "cleanup_branch", lambda branch: None)
     monkeypatch.setattr(implement_issue, "is_branch_empty", lambda branch: False)
     monkeypatch.setattr(
-        implement_issue, "verify_implementation", lambda branch: (False, "Tests failed")
+        implement_issue,
+        "verify_implementation",
+        lambda branch, issue_body="": (False, "Tests failed"),
     )
     monkeypatch.setattr(implement_issue, "post_attempt_failure", lambda n, a, e: None)
 
@@ -1024,7 +1133,7 @@ def test_implement_single_issue_logs_summed_token_totals(monkeypatch, tmp_path):
 
     verify_calls = [0]
 
-    def fake_verify(branch):
+    def fake_verify(branch, issue_body=""):
         verify_calls[0] += 1
         if verify_calls[0] < 2:
             return False, "attempt 1 failed"
@@ -1501,7 +1610,7 @@ def test_implement_single_issue_nonempty_branch_still_retries(monkeypatch, tmp_p
         attempt_count[0] += 1
         return _claude_result()
 
-    def fake_verify(branch):
+    def fake_verify(branch, issue_body=""):
         return False, "Tests failed:\nsome test output"
 
     monkeypatch.setattr(implement_issue, "implement", fake_implement)

--- a/tests/test_triage_issues.py
+++ b/tests/test_triage_issues.py
@@ -485,6 +485,85 @@ def test_create_sub_issues_uses_cfg_repo(monkeypatch):
         assert call[call.index("--repo") + 1] == "acme/widgets"
 
 
+def test_create_sub_issues_inherits_parent_type(monkeypatch):
+    """Sub-issues inherit the parent's issue type instead of hardcoding 'feature'."""
+    cfg = _cfg(repo="acme/widgets")
+    monkeypatch.setattr("shutil.which", lambda cmd: None)
+
+    bodies: list[str] = []
+
+    class FakeResult:
+        returncode = 0
+        stdout = "https://github.com/acme/widgets/issues/99"
+
+    def fake_run(cmd, **_kwargs):
+        if cmd[0] == "gh" and cmd[2] == "create":
+            body_idx = cmd.index("--body") + 1
+            bodies.append(cmd[body_idx])
+        return FakeResult()
+
+    result = {
+        "decomposition": [
+            {
+                "order": 1,
+                "title": "Step 1",
+                "points": 2,
+                "depends_on": [],
+                "files": ["pyproject.toml"],
+            },
+        ],
+    }
+
+    parent_body = "## Summary\nMigrate to uv\n\n## Type\nrefactor"
+    with patch("autoloop.triage_issues.subprocess.run", side_effect=fake_run):
+        from autoloop.triage_issues import create_sub_issues
+
+        created = create_sub_issues(10, result, cfg, parent_summary=parent_body)
+
+    assert len(created) == 1
+    assert "## Type\nrefactor" in bodies[0]
+    assert "## Type\nfeature" not in bodies[0]
+
+
+def test_create_sub_issues_migration_parent_inherits_refactor(monkeypatch):
+    """A migration parent produces sub-issues with type refactor."""
+    cfg = _cfg(repo="acme/widgets")
+    monkeypatch.setattr("shutil.which", lambda cmd: None)
+
+    bodies: list[str] = []
+
+    class FakeResult:
+        returncode = 0
+        stdout = "https://github.com/acme/widgets/issues/99"
+
+    def fake_run(cmd, **_kwargs):
+        if cmd[0] == "gh" and cmd[2] == "create":
+            body_idx = cmd.index("--body") + 1
+            bodies.append(cmd[body_idx])
+        return FakeResult()
+
+    result = {
+        "decomposition": [
+            {
+                "order": 1,
+                "title": "Step 1",
+                "points": 2,
+                "depends_on": [],
+                "files": ["pyproject.toml"],
+            },
+        ],
+    }
+
+    parent_body = "## Summary\nMigrate backend\n\n## Type\nmigration"
+    with patch("autoloop.triage_issues.subprocess.run", side_effect=fake_run):
+        from autoloop.triage_issues import create_sub_issues
+
+        created = create_sub_issues(10, result, cfg, parent_summary=parent_body)
+
+    assert len(created) == 1
+    assert "## Type\nrefactor" in bodies[0]
+
+
 # --- Claude calls use cfg.triage_model ---
 
 


### PR DESCRIPTION
Closes #61

## Summary
fix: skip test-file gate for refactor/migration/docs issues instead of failing valid work

## Test Plan
- `uv run pytest` — all tests pass

## AutoLoop Run Stats
- Attempts: 1/3
- Duration: 310s
- Input tokens: 7,969
- Output tokens: 10,895
- Cost: $2.51

Automated implementation by AutoLoop.