### PR TITLE
feat: feat: scaffold doctor subcommand with check runner framework (#69)

### DIFF
--- a/src/autoloop/cli.py
+++ b/src/autoloop/cli.py
@@ -66,6 +66,9 @@ def main():
     )
     acp_parser.add_argument("pr_number", type=int, help="PR number to check")
 
+    # doctor
+    subparsers.add_parser("doctor", help="Run environment and config checks")
+
     # preflight
     subparsers.add_parser("preflight", help="Run verify and lint commands on the current branch")
 
@@ -129,6 +132,13 @@ def main():
             print(f"Closed parent issue #{result}")
         else:
             print("No parent issue to close.")
+
+    elif args.command == "doctor":
+        from autoloop.doctor import run_checks
+
+        results = run_checks([])
+        if any(not r.passed for r in results):
+            sys.exit(1)
 
     elif args.command == "preflight":
         from autoloop.config import load_config

--- a/src/autoloop/doctor.py
+++ b/src/autoloop/doctor.py
@@ -1,0 +1,48 @@
+"""Doctor subcommand — check runner framework."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+
+@dataclass
+class Check:
+    name: str
+    fn: Callable[[], tuple[bool, str]]
+    fix_hint: str
+
+
+@dataclass
+class Result:
+    name: str
+    passed: bool
+    message: str
+    fix_hint: str
+
+
+def run_checks(checks: list[Check]) -> list[Result]:
+    """Run each check, print pass/fail, return results."""
+    if not checks:
+        print("No checks registered.")
+        return []
+
+    results: list[Result] = []
+    for check in checks:
+        try:
+            passed, message = check.fn()
+        except Exception as exc:
+            passed = False
+            message = str(exc)
+
+        results.append(
+            Result(name=check.name, passed=passed, message=message, fix_hint=check.fix_hint)
+        )
+
+        if passed:
+            print(f"\033[32m✓\033[0m {check.name}: {message}")
+        else:
+            print(f"\033[31m✗\033[0m {check.name}: {message}")
+            print(f"  hint: {check.fix_hint}")
+
+    return results

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,0 +1,73 @@
+"""Tests for autoloop doctor check runner."""
+
+from __future__ import annotations
+
+from autoloop.doctor import Check, Result, run_checks
+
+
+def test_run_checks_all_pass(capsys):
+    checks = [
+        Check(name="alpha", fn=lambda: (True, "ok"), fix_hint="fix alpha"),
+        Check(name="beta", fn=lambda: (True, "good"), fix_hint="fix beta"),
+    ]
+    results = run_checks(checks)
+
+    assert len(results) == 2
+    assert all(r.passed for r in results)
+    assert results[0].name == "alpha"
+    assert results[1].name == "beta"
+
+    out = capsys.readouterr().out
+    assert "✓" in out
+    assert "✗" not in out
+
+
+def test_run_checks_one_fails(capsys):
+    checks = [
+        Check(name="good", fn=lambda: (True, "fine"), fix_hint="n/a"),
+        Check(name="bad", fn=lambda: (False, "broken"), fix_hint="run repair"),
+    ]
+    results = run_checks(checks)
+
+    assert results[0].passed is True
+    assert results[1].passed is False
+    assert results[1].fix_hint == "run repair"
+
+    out = capsys.readouterr().out
+    assert "✓" in out
+    assert "✗" in out
+    assert "hint: run repair" in out
+
+
+def test_run_checks_exception_in_fn(capsys):
+    def boom():
+        raise RuntimeError("unexpected error")
+
+    checks = [
+        Check(name="exploder", fn=boom, fix_hint="check logs"),
+    ]
+    results = run_checks(checks)
+
+    assert len(results) == 1
+    assert results[0].passed is False
+    assert "unexpected error" in results[0].message
+
+    out = capsys.readouterr().out
+    assert "✗" in out
+    assert "hint: check logs" in out
+
+
+def test_run_checks_empty(capsys):
+    results = run_checks([])
+
+    assert results == []
+    out = capsys.readouterr().out
+    assert "No checks registered." in out
+
+
+def test_result_dataclass():
+    r = Result(name="test", passed=True, message="ok", fix_hint="none")
+    assert r.name == "test"
+    assert r.passed is True
+    assert r.message == "ok"
+    assert r.fix_hint == "none"


### PR DESCRIPTION
Closes #69

## Summary
feat: scaffold doctor subcommand with check runner framework

## Test Plan
- `uv run pytest` — all tests pass

## AutoLoop Run Stats
- Attempts: 1/3
- Duration: 106s
- Input tokens: 14
- Output tokens: 3,036
- Cost: $0.40

Automated implementation by AutoLoop.