### PR TITLE
feat: feat: doctor check — validate autoloop.toml and .claude/sett (#70)

### DIFF
--- a/src/autoloop/cli.py
+++ b/src/autoloop/cli.py
@@ -134,9 +134,9 @@ def main():
             print("No parent issue to close.")
 
     elif args.command == "doctor":
-        from autoloop.doctor import run_checks
+        from autoloop.doctor import get_checks, run_checks
 
-        results = run_checks([])
+        results = run_checks(get_checks())
         if any(not r.passed for r in results):
             sys.exit(1)
 

--- a/src/autoloop/doctor.py
+++ b/src/autoloop/doctor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Callable
 
 
@@ -19,6 +20,44 @@ class Result:
     passed: bool
     message: str
     fix_hint: str
+
+
+def check_autoloop_toml(repo_dir: Path | None = None) -> tuple[bool, str]:
+    """Validate that autoloop.toml exists and parses without error."""
+    from autoloop.config import load_config
+
+    config_path = (repo_dir or Path.cwd()) / "autoloop.toml"
+    try:
+        load_config(config_path)
+    except FileNotFoundError:
+        return False, "autoloop.toml not found"
+    except Exception as exc:
+        return False, f"autoloop.toml invalid: {exc}"
+    return True, "autoloop.toml found and valid"
+
+
+def check_claude_settings(repo_dir: Path | None = None) -> tuple[bool, str]:
+    """Validate that .claude/settings.json exists in the repo root."""
+    settings_path = (repo_dir or Path.cwd()) / ".claude" / "settings.json"
+    if not settings_path.exists():
+        return False, ".claude/settings.json not found"
+    return True, ".claude/settings.json found"
+
+
+def get_checks(repo_dir: Path | None = None) -> list[Check]:
+    """Return the default set of doctor checks."""
+    return [
+        Check(
+            name="autoloop.toml",
+            fn=lambda: check_autoloop_toml(repo_dir),
+            fix_hint='run "autoloop init" to generate it',
+        ),
+        Check(
+            name=".claude/settings.json",
+            fn=lambda: check_claude_settings(repo_dir),
+            fix_hint='run "autoloop init" to scaffold it, or create manually',
+        ),
+    ]
 
 
 def run_checks(checks: list[Check]) -> list[Result]:

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -2,7 +2,14 @@
 
 from __future__ import annotations
 
-from autoloop.doctor import Check, Result, run_checks
+from autoloop.doctor import (
+    Check,
+    Result,
+    check_autoloop_toml,
+    check_claude_settings,
+    get_checks,
+    run_checks,
+)
 
 
 def test_run_checks_all_pass(capsys):
@@ -71,3 +78,85 @@ def test_result_dataclass():
     assert r.passed is True
     assert r.message == "ok"
     assert r.fix_hint == "none"
+
+
+# --- autoloop.toml check ---
+
+
+def test_check_autoloop_toml_exists_and_valid(tmp_path):
+    toml_file = tmp_path / "autoloop.toml"
+    toml_file.write_text('repo = "acme/widgets"\n')
+    passed, msg = check_autoloop_toml(tmp_path)
+    assert passed is True
+    assert "found and valid" in msg
+
+
+def test_check_autoloop_toml_missing(tmp_path):
+    passed, msg = check_autoloop_toml(tmp_path)
+    assert passed is False
+    assert "not found" in msg
+
+
+def test_check_autoloop_toml_invalid_syntax(tmp_path):
+    toml_file = tmp_path / "autoloop.toml"
+    toml_file.write_text("[invalid toml\nno closing bracket")
+    passed, msg = check_autoloop_toml(tmp_path)
+    assert passed is False
+    assert "invalid" in msg
+
+
+# --- .claude/settings.json check ---
+
+
+def test_check_claude_settings_exists(tmp_path):
+    settings_dir = tmp_path / ".claude"
+    settings_dir.mkdir()
+    (settings_dir / "settings.json").write_text("{}")
+    passed, msg = check_claude_settings(tmp_path)
+    assert passed is True
+    assert "found" in msg
+
+
+def test_check_claude_settings_missing(tmp_path):
+    passed, msg = check_claude_settings(tmp_path)
+    assert passed is False
+    assert "not found" in msg
+
+
+# --- get_checks integration ---
+
+
+def test_get_checks_returns_registered_checks():
+    checks = get_checks()
+    assert len(checks) == 2
+    assert checks[0].name == "autoloop.toml"
+    assert checks[1].name == ".claude/settings.json"
+    assert "autoloop init" in checks[0].fix_hint
+    assert "autoloop init" in checks[1].fix_hint
+
+
+def test_get_checks_all_pass(tmp_path, capsys):
+    toml_file = tmp_path / "autoloop.toml"
+    toml_file.write_text('repo = "acme/widgets"\n')
+    settings_dir = tmp_path / ".claude"
+    settings_dir.mkdir()
+    (settings_dir / "settings.json").write_text("{}")
+
+    checks = get_checks(tmp_path)
+    results = run_checks(checks)
+
+    assert len(results) == 2
+    assert all(r.passed for r in results)
+    out = capsys.readouterr().out
+    assert "✓" in out
+    assert "✗" not in out
+
+
+def test_get_checks_all_fail(tmp_path, capsys):
+    checks = get_checks(tmp_path)
+    results = run_checks(checks)
+
+    assert len(results) == 2
+    assert all(not r.passed for r in results)
+    out = capsys.readouterr().out
+    assert "✗" in out


### PR DESCRIPTION
Closes #70

## Summary
feat: doctor check — validate autoloop.toml and .claude/settings.json

## Test Plan
- `uv run pytest` — all tests pass

## AutoLoop Run Stats
- Attempts: 1/3
- Duration: 124s
- Input tokens: 12
- Output tokens: 5,863
- Cost: $0.49

Automated implementation by AutoLoop.