### PR TITLE
fix: fix: post actionable guidance on implement timeout — not jus (#66)

### DIFF
--- a/src/autoloop/claude_runner.py
+++ b/src/autoloop/claude_runner.py
@@ -19,6 +19,7 @@ class ClaudeResult:
     output_tokens: int
     cache_read_tokens: int
     success: bool
+    timed_out: bool = False
 
 
 def run_claude(prompt: str, model: str, timeout: int) -> ClaudeResult:
@@ -37,7 +38,7 @@ def run_claude(prompt: str, model: str, timeout: int) -> ClaudeResult:
             timeout=timeout,
         )
     except subprocess.TimeoutExpired:
-        return ClaudeResult("", 0, 0, 0, 0, success=False)
+        return ClaudeResult("", 0, 0, 0, 0, success=False, timed_out=True)
 
     if result.returncode != 0:
         return ClaudeResult("", 0, 0, 0, 0, success=False)

--- a/src/autoloop/implement_issue.py
+++ b/src/autoloop/implement_issue.py
@@ -593,6 +593,26 @@ def design_gate(issue: dict, require_design: bool = False) -> bool:
     return False
 
 
+def build_timeout_comment(attempt: int, timeout_seconds: int) -> str:
+    """Build an actionable guidance comment for implementation timeout."""
+    return (
+        f"**AutoLoop Attempt {attempt} failed: implementation timeout ({timeout_seconds}s)**\n\n"
+        f"Possible fixes:\n"
+        f"- Increase timeout: set `impl_timeout = {timeout_seconds * 2}` in autoloop.toml\n"
+        f"- Or set env var: `AUTOLOOP_TIMEOUT={timeout_seconds * 2}`\n"
+        f"- Decompose the issue into smaller sub-issues (target ≤ 2 story points)\n"
+        f"- Add implementation hints to the issue body to reduce exploration time"
+    )
+
+
+def post_timeout_failure(number: int, attempt: int, timeout_seconds: int):
+    """Post timeout failure with actionable guidance as a comment on the issue."""
+    comment = build_timeout_comment(attempt, timeout_seconds)
+    subprocess.run(
+        ["gh", "issue", "comment", str(number), "--repo", cfg.repo, "--body", comment],
+    )
+
+
 def post_attempt_failure(number: int, attempt: int, errors: str):
     """Post verification failure as a comment on the issue."""
     comment = f"**AutoLoop Attempt {attempt} failed:**\n\n```\n{errors[-2000:]}\n```"
@@ -969,10 +989,18 @@ def implement_single_issue(issue: dict, require_design: bool = False) -> bool:
 
         last_errors = None
         empty_branch_failure = False
+        timeout_failure = False
         for attempt in range(1, cfg.max_retries + 1):
             print(f"  Attempt {attempt}/{cfg.max_retries}...")
-            claude_results.append(implement(issue, previous_errors=last_errors))
+            result = implement(issue, previous_errors=last_errors)
+            claude_results.append(result)
             final_attempt = attempt
+
+            if result.timed_out:
+                print(f"  Implementation timed out after {cfg.impl_timeout}s.")
+                post_timeout_failure(issue["number"], attempt, cfg.impl_timeout)
+                timeout_failure = True
+                break
 
             if is_branch_empty(branch):
                 print(f"  {EMPTY_BRANCH_DIAGNOSTIC}")
@@ -1006,7 +1034,9 @@ def implement_single_issue(issue: dict, require_design: bool = False) -> bool:
         total_cache_read = sum(r.cache_read_tokens for r in claude_results)
 
         if not success:
-            if empty_branch_failure:
+            if timeout_failure:
+                print("  Implementation timed out. Labeling needs-human.")
+            elif empty_branch_failure:
                 print("  Implementation produced no changes. Labeling needs-human.")
             else:
                 print("  All retries exhausted. Labeling needs-human.")

--- a/tests/test_claude_runner.py
+++ b/tests/test_claude_runner.py
@@ -89,7 +89,8 @@ def test_run_claude_timeout_returns_failure(monkeypatch):
 
     result = run_claude("p", "opus", 1)
 
-    assert result == ClaudeResult("", 0, 0, 0, 0, success=False)
+    assert result == ClaudeResult("", 0, 0, 0, 0, success=False, timed_out=True)
+    assert result.timed_out is True
 
 
 def test_run_claude_nonzero_exit_returns_failure(monkeypatch):
@@ -99,6 +100,7 @@ def test_run_claude_nonzero_exit_returns_failure(monkeypatch):
     result = run_claude("p", "opus", 10)
 
     assert result.success is False
+    assert result.timed_out is False
     assert result.cost_usd == 0
     assert result.input_tokens == 0
 

--- a/tests/test_implement_issue.py
+++ b/tests/test_implement_issue.py
@@ -1476,6 +1476,7 @@ def test_main_default_implements_one_issue(monkeypatch, tmp_path, capsys):
     lock_path = tmp_path / ".autoloop.lock"
     monkeypatch.setattr(implement_issue, "LOCKFILE", lock_path)
     monkeypatch.setattr(implement_issue, "load_config", lambda path=None: _test_cfg())
+    monkeypatch.setattr(implement_issue, "detect_active_claude_session", lambda: False)
 
     issues = [{"number": 1, "title": "Issue one", "body": "", "labels": []}]
     call_count = [0]
@@ -1506,6 +1507,7 @@ def test_main_no_ready_issues_prints_message(monkeypatch, tmp_path, capsys):
     lock_path = tmp_path / ".autoloop.lock"
     monkeypatch.setattr(implement_issue, "LOCKFILE", lock_path)
     monkeypatch.setattr(implement_issue, "load_config", lambda path=None: _test_cfg())
+    monkeypatch.setattr(implement_issue, "detect_active_claude_session", lambda: False)
     monkeypatch.setattr(implement_issue, "get_top_ready_issue", lambda: None)
     monkeypatch.setattr(implement_issue, "cleanup_merged_labels", lambda: None)
     monkeypatch.setattr(implement_issue, "unblock_ready_issues", lambda: None)
@@ -1520,6 +1522,7 @@ def test_main_issue_flag_targets_specific_issue(monkeypatch, tmp_path):
     lock_path = tmp_path / ".autoloop.lock"
     monkeypatch.setattr(implement_issue, "LOCKFILE", lock_path)
     monkeypatch.setattr(implement_issue, "load_config", lambda path=None: _test_cfg())
+    monkeypatch.setattr(implement_issue, "detect_active_claude_session", lambda: False)
     monkeypatch.setattr(implement_issue, "cleanup_merged_labels", lambda: None)
     monkeypatch.setattr(implement_issue, "unblock_ready_issues", lambda: None)
 

--- a/tests/test_implement_issue.py
+++ b/tests/test_implement_issue.py
@@ -12,6 +12,7 @@ from autoloop.implement_issue import (
     acquire_lock,
     build_branch_name,
     build_pr_body,
+    build_timeout_comment,
     cleanup_merged_labels,
     collect_verification_errors,
     create_branch,
@@ -35,6 +36,7 @@ from autoloop.implement_issue import (
     parse_dependency_numbers,
     parse_review_response,
     post_in_progress_comment,
+    post_timeout_failure,
     priority_rank,
     release_lock,
     review_implementation,
@@ -60,7 +62,12 @@ def _test_cfg(**overrides):
 
 
 def _claude_result(
-    cost_usd=1.5, input_tokens=1000, output_tokens=200, cache_read_tokens=500, success=True
+    cost_usd=1.5,
+    input_tokens=1000,
+    output_tokens=200,
+    cache_read_tokens=500,
+    success=True,
+    timed_out=False,
 ):
     return ClaudeResult(
         text="",
@@ -69,6 +76,7 @@ def _claude_result(
         output_tokens=output_tokens,
         cache_read_tokens=cache_read_tokens,
         success=success,
+        timed_out=timed_out,
     )
 
 
@@ -507,6 +515,62 @@ def test_post_attempt_failure_uses_cfg_repo(monkeypatch):
     implement_issue.post_attempt_failure(42, 2, "Tests failed")
 
     assert captured["cmd"][captured["cmd"].index("--repo") + 1] == "my-org/my-repo"
+
+
+# --- build_timeout_comment tests ---
+
+
+def test_build_timeout_comment_includes_timeout_duration():
+    comment = build_timeout_comment(1, 900)
+    assert "implementation timeout (900s)" in comment
+
+
+def test_build_timeout_comment_includes_attempt_number():
+    comment = build_timeout_comment(2, 900)
+    assert "Attempt 2 failed" in comment
+
+
+def test_build_timeout_comment_suggests_doubled_timeout():
+    comment = build_timeout_comment(1, 900)
+    assert "impl_timeout = 1800" in comment
+    assert "AUTOLOOP_TIMEOUT=1800" in comment
+
+
+def test_build_timeout_comment_suggests_decomposition():
+    comment = build_timeout_comment(1, 900)
+    assert "Decompose the issue into smaller sub-issues" in comment
+
+
+def test_build_timeout_comment_suggests_hints():
+    comment = build_timeout_comment(1, 900)
+    assert "implementation hints" in comment
+
+
+def test_build_timeout_comment_with_custom_timeout():
+    comment = build_timeout_comment(1, 1800)
+    assert "implementation timeout (1800s)" in comment
+    assert "impl_timeout = 3600" in comment
+    assert "AUTOLOOP_TIMEOUT=3600" in comment
+
+
+# --- post_timeout_failure tests ---
+
+
+def test_post_timeout_failure_uses_cfg_repo(monkeypatch):
+    monkeypatch.setattr(implement_issue, "cfg", _test_cfg(repo="my-org/my-repo"))
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return type("R", (), {"returncode": 0})()
+
+    monkeypatch.setattr(implement_issue.subprocess, "run", fake_run)
+    post_timeout_failure(42, 1, 900)
+
+    assert captured["cmd"][captured["cmd"].index("--repo") + 1] == "my-org/my-repo"
+    body = captured["cmd"][captured["cmd"].index("--body") + 1]
+    assert "implementation timeout (900s)" in body
+    assert "impl_timeout = 1800" in body
 
 
 def test_cleanup_merged_labels_uses_cfg_repo(monkeypatch):
@@ -1619,6 +1683,102 @@ def test_implement_single_issue_nonempty_branch_still_retries(monkeypatch, tmp_p
     monkeypatch.setattr(implement_issue, "cleanup_branch", lambda branch: None)
     monkeypatch.setattr(implement_issue, "is_branch_empty", lambda branch: False)
     monkeypatch.setattr(implement_issue, "verify_implementation", fake_verify)
+    monkeypatch.setattr(implement_issue, "post_attempt_failure", lambda n, a, e: None)
+    monkeypatch.setattr(
+        implement_issue.subprocess,
+        "run",
+        lambda *a, **kw: type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})(),
+    )
+
+    result = implement_single_issue(_FAKE_ISSUE)
+    assert result is False
+    assert attempt_count[0] == 3
+
+
+# --- Timeout handling in implement_single_issue ---
+
+
+def test_implement_single_issue_timeout_posts_guidance(monkeypatch, tmp_path):
+    """Timeout after attempt 1 posts actionable guidance and short-circuits."""
+    monkeypatch.setattr(implement_issue, "cfg", _test_cfg(max_retries=3, impl_timeout=900))
+    log_path = tmp_path / "run_history.jsonl"
+    monkeypatch.setattr(implement_issue, "LOG_FILE", log_path)
+
+    attempt_count = [0]
+
+    def fake_implement(issue, previous_errors=None):
+        attempt_count[0] += 1
+        return _claude_result(timed_out=True)
+
+    posted_comments = []
+
+    def fake_post_timeout(number, attempt, timeout_seconds):
+        posted_comments.append((number, attempt, timeout_seconds))
+
+    monkeypatch.setattr(implement_issue, "implement", fake_implement)
+    monkeypatch.setattr(implement_issue, "create_branch", lambda issue: "autoloop/42-x")
+    monkeypatch.setattr(implement_issue, "cleanup_branch", lambda branch: None)
+    monkeypatch.setattr(implement_issue, "post_timeout_failure", fake_post_timeout)
+    monkeypatch.setattr(
+        implement_issue.subprocess,
+        "run",
+        lambda *a, **kw: type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})(),
+    )
+
+    result = implement_single_issue(_FAKE_ISSUE)
+    assert result is False
+    assert attempt_count[0] == 1
+    assert len(posted_comments) == 1
+    assert posted_comments[0] == (42, 1, 900)
+
+
+def test_implement_single_issue_timeout_prints_message(monkeypatch, tmp_path, capsys):
+    """Timeout prints the appropriate console message."""
+    monkeypatch.setattr(implement_issue, "cfg", _test_cfg(max_retries=3, impl_timeout=600))
+    log_path = tmp_path / "run_history.jsonl"
+    monkeypatch.setattr(implement_issue, "LOG_FILE", log_path)
+
+    monkeypatch.setattr(
+        implement_issue,
+        "implement",
+        lambda issue, previous_errors=None: _claude_result(timed_out=True),
+    )
+    monkeypatch.setattr(implement_issue, "create_branch", lambda issue: "autoloop/42-x")
+    monkeypatch.setattr(implement_issue, "cleanup_branch", lambda branch: None)
+    monkeypatch.setattr(implement_issue, "post_timeout_failure", lambda n, a, t: None)
+    monkeypatch.setattr(
+        implement_issue.subprocess,
+        "run",
+        lambda *a, **kw: type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})(),
+    )
+
+    implement_single_issue(_FAKE_ISSUE)
+    output = capsys.readouterr().out
+    assert "timed out after 600s" in output
+    assert "timed out. Labeling needs-human" in output
+
+
+def test_implement_single_issue_non_timeout_failure_still_retries(monkeypatch, tmp_path):
+    """Non-timeout failures (success=False but not timed_out) proceed normally."""
+    monkeypatch.setattr(implement_issue, "cfg", _test_cfg(max_retries=3))
+    log_path = tmp_path / "run_history.jsonl"
+    monkeypatch.setattr(implement_issue, "LOG_FILE", log_path)
+
+    attempt_count = [0]
+
+    def fake_implement(issue, previous_errors=None):
+        attempt_count[0] += 1
+        return _claude_result()
+
+    monkeypatch.setattr(implement_issue, "implement", fake_implement)
+    monkeypatch.setattr(implement_issue, "create_branch", lambda issue: "autoloop/42-x")
+    monkeypatch.setattr(implement_issue, "cleanup_branch", lambda branch: None)
+    monkeypatch.setattr(implement_issue, "is_branch_empty", lambda branch: False)
+    monkeypatch.setattr(
+        implement_issue,
+        "verify_implementation",
+        lambda branch, issue_body="": (False, "Tests failed"),
+    )
     monkeypatch.setattr(implement_issue, "post_attempt_failure", lambda n, a, e: None)
     monkeypatch.setattr(
         implement_issue.subprocess,

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -8,7 +8,7 @@ README = (REPO_ROOT / "README.md").read_text()
 
 class TestTldrQuickstart:
     def test_section_exists(self):
-        assert "## TLDR — First PR in 5 Minutes" in README
+        assert "## TLDR: First PR in 5 Minutes" in README
 
     def test_appears_before_detailed_content(self):
         tldr_idx = README.index("## TLDR")
@@ -53,7 +53,7 @@ class TestPlatformSupport:
         assert "**Linux**" in README
 
     def test_windows_unsupported(self):
-        assert "**Windows** — not supported" in README
+        assert "**Windows**: not supported" in README
 
 
 class TestModeFraming:


### PR DESCRIPTION
Closes #66

## Summary
fix: post actionable guidance on implement timeout — not just failure label

## Test Plan
- `uv run pytest` — all tests pass

## AutoLoop Run Stats
- Attempts: 2/3
- Duration: 336s
- Input tokens: 40
- Output tokens: 13,247
- Cost: $2.39

Automated implementation by AutoLoop.