### PR TITLE
fix: fix: session detection blocks implement when Claude runs in  (#82)

### DIFF
--- a/src/autoloop/config.py
+++ b/src/autoloop/config.py
@@ -43,6 +43,7 @@ class AutoLoopConfig:
             "needs-human",
         ]
     )
+    project_dir: str = ""
 
 
 _ENV_MAP: dict[str, tuple[str, type]] = {
@@ -67,6 +68,7 @@ def load_config(path: Path | None = None) -> AutoLoopConfig:
     if not config_path.exists():
         raise FileNotFoundError(f"Config file not found: {config_path}")
     config = AutoLoopConfig()
+    config.project_dir = str(config_path.parent.resolve())
 
     with open(config_path, "rb") as f:
         data = tomllib.load(f)

--- a/src/autoloop/implement_issue.py
+++ b/src/autoloop/implement_issue.py
@@ -1131,7 +1131,8 @@ def main(issue=None, max_issues=1, require_design=False):
     if cfg is None:
         cfg = load_config()
 
-    session_detected = detect_active_claude_session(str(REPO_DIR))
+    logging.debug("main: resolved project_dir=%s from cfg", cfg.project_dir)
+    session_detected = detect_active_claude_session(cfg.project_dir)
     if session_detected is True:
         print(
             "Active Claude Code session detected in this directory.\n"

--- a/src/autoloop/implement_issue.py
+++ b/src/autoloop/implement_issue.py
@@ -15,6 +15,7 @@ import re
 import subprocess
 import time
 from datetime import UTC, datetime
+from pathlib import Path
 
 from autoloop.claude_runner import ClaudeResult, run_claude
 from autoloop.config import REPO_DIR, load_config
@@ -206,6 +207,7 @@ def detect_active_claude_session(project_dir: str | None = None) -> bool | None:
         project_dir = str(REPO_DIR)
 
     project_dir = os.path.realpath(project_dir)
+    logging.debug("detect_active_claude_session: resolved project_dir=%s", project_dir)
 
     try:
         result = subprocess.run(
@@ -257,6 +259,7 @@ def _check_cwd_lsof(pids: list[int], project_dir: str) -> bool | None:
     for line in result.stdout.splitlines():
         if line.startswith("n"):
             cwd = os.path.realpath(line[1:])
+            logging.debug("detect_active_claude_session: session cwd=%s", cwd)
             if cwd == project_dir:
                 return True
 
@@ -270,6 +273,7 @@ def _check_cwd_proc(pids: list[int], project_dir: str) -> bool | None:
         try:
             cwd = os.path.realpath(f"/proc/{pid}/cwd")
             checked_any = True
+            logging.debug("detect_active_claude_session: session cwd=%s", cwd)
             if cwd == project_dir:
                 return True
         except (OSError, PermissionError):
@@ -1128,7 +1132,8 @@ def main(issue=None, max_issues=1, require_design=False):
     if cfg is None:
         cfg = load_config()
 
-    session_detected = detect_active_claude_session()
+    project_dir = str(Path.cwd())
+    session_detected = detect_active_claude_session(project_dir)
     if session_detected is True:
         print(
             "Active Claude Code session detected in this directory.\n"

--- a/src/autoloop/implement_issue.py
+++ b/src/autoloop/implement_issue.py
@@ -15,7 +15,6 @@ import re
 import subprocess
 import time
 from datetime import UTC, datetime
-from pathlib import Path
 
 from autoloop.claude_runner import ClaudeResult, run_claude
 from autoloop.config import REPO_DIR, load_config
@@ -1132,8 +1131,7 @@ def main(issue=None, max_issues=1, require_design=False):
     if cfg is None:
         cfg = load_config()
 
-    project_dir = str(Path.cwd())
-    session_detected = detect_active_claude_session(project_dir)
+    session_detected = detect_active_claude_session(str(REPO_DIR))
     if session_detected is True:
         print(
             "Active Claude Code session detected in this directory.\n"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -42,6 +42,19 @@ def test_load_from_toml(autoloop_toml, monkeypatch):
     assert config.triage_labels == ["ready", "blocked"]
 
 
+def test_load_config_sets_project_dir_from_config_path(tmp_path, monkeypatch):
+    for var in ("AUTOLOOP_TRIAGE_MODEL", "AUTOLOOP_IMPL_MODEL", "AUTOLOOP_TIMEOUT"):
+        monkeypatch.delenv(var, raising=False)
+
+    subdir = tmp_path / "nested" / "project"
+    subdir.mkdir(parents=True)
+    toml_path = subdir / "autoloop.toml"
+    toml_path.write_text('repo = "acme-corp/widget"\n')
+
+    config = load_config(toml_path)
+    assert config.project_dir == str(subdir.resolve())
+
+
 def test_partial_toml_keeps_defaults(tmp_path, monkeypatch):
     for var in (
         "AUTOLOOP_TRIAGE_MODEL",

--- a/tests/test_implement_issue.py
+++ b/tests/test_implement_issue.py
@@ -1987,14 +1987,18 @@ def test_detect_active_claude_session_uses_explicit_path_not_import_cwd(monkeypa
     assert detect_active_claude_session("/different/path") is False
 
 
-def test_main_passes_cwd_to_detect_active_claude_session(monkeypatch, tmp_path, capsys):
-    """main() passes the current working directory, not module-level REPO_DIR."""
+def test_main_passes_repo_dir_to_detect_active_claude_session(monkeypatch, tmp_path, capsys):
+    """main() passes REPO_DIR explicitly, not None or a call-time cwd."""
     lock_path = tmp_path / ".autoloop.lock"
     monkeypatch.setattr(implement_issue, "LOCKFILE", lock_path)
     monkeypatch.setattr(implement_issue, "load_config", lambda path=None: _test_cfg())
     monkeypatch.setattr(implement_issue, "get_top_ready_issue", lambda: None)
     monkeypatch.setattr(implement_issue, "cleanup_merged_labels", lambda: None)
     monkeypatch.setattr(implement_issue, "unblock_ready_issues", lambda: None)
+
+    fake_repo = tmp_path / "fake_repo"
+    fake_repo.mkdir()
+    monkeypatch.setattr(implement_issue, "REPO_DIR", fake_repo)
 
     captured_dirs = []
 
@@ -2008,7 +2012,7 @@ def test_main_passes_cwd_to_detect_active_claude_session(monkeypatch, tmp_path, 
     implement_issue.main()
 
     assert len(captured_dirs) == 1
-    assert captured_dirs[0] is not None, "main() must pass an explicit project_dir"
+    assert captured_dirs[0] == str(fake_repo), "main() must pass REPO_DIR as project_dir"
 
 
 # --- truncate_spec tests ---

--- a/tests/test_implement_issue.py
+++ b/tests/test_implement_issue.py
@@ -1987,18 +1987,25 @@ def test_detect_active_claude_session_uses_explicit_path_not_import_cwd(monkeypa
     assert detect_active_claude_session("/different/path") is False
 
 
-def test_main_passes_repo_dir_to_detect_active_claude_session(monkeypatch, tmp_path, capsys):
-    """main() passes REPO_DIR explicitly, not None or a call-time cwd."""
+def test_main_passes_cfg_project_dir_to_detect_active_claude_session(monkeypatch, tmp_path, capsys):
+    """main() passes cfg.project_dir, not REPO_DIR or None."""
     lock_path = tmp_path / ".autoloop.lock"
     monkeypatch.setattr(implement_issue, "LOCKFILE", lock_path)
-    monkeypatch.setattr(implement_issue, "load_config", lambda path=None: _test_cfg())
+
+    cfg_project = tmp_path / "cfg_project"
+    cfg_project.mkdir()
+    monkeypatch.setattr(
+        implement_issue,
+        "load_config",
+        lambda path=None: _test_cfg(project_dir=str(cfg_project)),
+    )
     monkeypatch.setattr(implement_issue, "get_top_ready_issue", lambda: None)
     monkeypatch.setattr(implement_issue, "cleanup_merged_labels", lambda: None)
     monkeypatch.setattr(implement_issue, "unblock_ready_issues", lambda: None)
 
-    fake_repo = tmp_path / "fake_repo"
-    fake_repo.mkdir()
-    monkeypatch.setattr(implement_issue, "REPO_DIR", fake_repo)
+    import_time_repo = tmp_path / "import_time_repo"
+    import_time_repo.mkdir()
+    monkeypatch.setattr(implement_issue, "REPO_DIR", import_time_repo)
 
     captured_dirs = []
 
@@ -2012,7 +2019,8 @@ def test_main_passes_repo_dir_to_detect_active_claude_session(monkeypatch, tmp_p
     implement_issue.main()
 
     assert len(captured_dirs) == 1
-    assert captured_dirs[0] == str(fake_repo), "main() must pass REPO_DIR as project_dir"
+    assert captured_dirs[0] == str(cfg_project), "main() must pass cfg.project_dir, not REPO_DIR"
+    assert captured_dirs[0] != str(import_time_repo), "main() must not use module-level REPO_DIR"
 
 
 # --- truncate_spec tests ---

--- a/tests/test_implement_issue.py
+++ b/tests/test_implement_issue.py
@@ -1476,7 +1476,9 @@ def test_main_default_implements_one_issue(monkeypatch, tmp_path, capsys):
     lock_path = tmp_path / ".autoloop.lock"
     monkeypatch.setattr(implement_issue, "LOCKFILE", lock_path)
     monkeypatch.setattr(implement_issue, "load_config", lambda path=None: _test_cfg())
-    monkeypatch.setattr(implement_issue, "detect_active_claude_session", lambda: False)
+    monkeypatch.setattr(
+        implement_issue, "detect_active_claude_session", lambda project_dir=None: False
+    )
 
     issues = [{"number": 1, "title": "Issue one", "body": "", "labels": []}]
     call_count = [0]
@@ -1507,7 +1509,9 @@ def test_main_no_ready_issues_prints_message(monkeypatch, tmp_path, capsys):
     lock_path = tmp_path / ".autoloop.lock"
     monkeypatch.setattr(implement_issue, "LOCKFILE", lock_path)
     monkeypatch.setattr(implement_issue, "load_config", lambda path=None: _test_cfg())
-    monkeypatch.setattr(implement_issue, "detect_active_claude_session", lambda: False)
+    monkeypatch.setattr(
+        implement_issue, "detect_active_claude_session", lambda project_dir=None: False
+    )
     monkeypatch.setattr(implement_issue, "get_top_ready_issue", lambda: None)
     monkeypatch.setattr(implement_issue, "cleanup_merged_labels", lambda: None)
     monkeypatch.setattr(implement_issue, "unblock_ready_issues", lambda: None)
@@ -1522,7 +1526,9 @@ def test_main_issue_flag_targets_specific_issue(monkeypatch, tmp_path):
     lock_path = tmp_path / ".autoloop.lock"
     monkeypatch.setattr(implement_issue, "LOCKFILE", lock_path)
     monkeypatch.setattr(implement_issue, "load_config", lambda path=None: _test_cfg())
-    monkeypatch.setattr(implement_issue, "detect_active_claude_session", lambda: False)
+    monkeypatch.setattr(
+        implement_issue, "detect_active_claude_session", lambda project_dir=None: False
+    )
     monkeypatch.setattr(implement_issue, "cleanup_merged_labels", lambda: None)
     monkeypatch.setattr(implement_issue, "unblock_ready_issues", lambda: None)
 
@@ -1930,7 +1936,9 @@ def test_main_aborts_when_active_session_detected(monkeypatch, tmp_path, capsys)
     lock_path = tmp_path / ".autoloop.lock"
     monkeypatch.setattr(implement_issue, "LOCKFILE", lock_path)
     monkeypatch.setattr(implement_issue, "load_config", lambda path=None: _test_cfg())
-    monkeypatch.setattr(implement_issue, "detect_active_claude_session", lambda: True)
+    monkeypatch.setattr(
+        implement_issue, "detect_active_claude_session", lambda project_dir=None: True
+    )
 
     implement_issue.cfg = None
     implement_issue.main()
@@ -1944,7 +1952,9 @@ def test_main_proceeds_when_session_detection_inconclusive(monkeypatch, tmp_path
     lock_path = tmp_path / ".autoloop.lock"
     monkeypatch.setattr(implement_issue, "LOCKFILE", lock_path)
     monkeypatch.setattr(implement_issue, "load_config", lambda path=None: _test_cfg())
-    monkeypatch.setattr(implement_issue, "detect_active_claude_session", lambda: None)
+    monkeypatch.setattr(
+        implement_issue, "detect_active_claude_session", lambda project_dir=None: None
+    )
     monkeypatch.setattr(implement_issue, "get_top_ready_issue", lambda: None)
     monkeypatch.setattr(implement_issue, "cleanup_merged_labels", lambda: None)
     monkeypatch.setattr(implement_issue, "unblock_ready_issues", lambda: None)
@@ -1954,6 +1964,51 @@ def test_main_proceeds_when_session_detection_inconclusive(monkeypatch, tmp_path
     out = capsys.readouterr().out
     assert "Active Claude Code session" not in out
     assert "No more ready issues." in out
+
+
+def test_detect_active_claude_session_uses_explicit_path_not_import_cwd(monkeypatch):
+    """Passing an explicit project_dir evaluates against that path, not REPO_DIR."""
+    monkeypatch.setattr(implement_issue.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(implement_issue.os.path, "realpath", lambda p: p)
+
+    def fake_run(cmd, **kwargs):
+        if cmd[0] == "pgrep":
+            return type("R", (), {"returncode": 0, "stdout": "12345 claude\n", "stderr": ""})()
+        if cmd[0] == "lsof":
+            return type(
+                "R", (), {"returncode": 0, "stdout": "p12345\nn/explicit/path\n", "stderr": ""}
+            )()
+        return type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    monkeypatch.setattr(implement_issue.subprocess, "run", fake_run)
+    monkeypatch.setattr(implement_issue, "REPO_DIR", "/import/time/cwd")
+
+    assert detect_active_claude_session("/explicit/path") is True
+    assert detect_active_claude_session("/different/path") is False
+
+
+def test_main_passes_cwd_to_detect_active_claude_session(monkeypatch, tmp_path, capsys):
+    """main() passes the current working directory, not module-level REPO_DIR."""
+    lock_path = tmp_path / ".autoloop.lock"
+    monkeypatch.setattr(implement_issue, "LOCKFILE", lock_path)
+    monkeypatch.setattr(implement_issue, "load_config", lambda path=None: _test_cfg())
+    monkeypatch.setattr(implement_issue, "get_top_ready_issue", lambda: None)
+    monkeypatch.setattr(implement_issue, "cleanup_merged_labels", lambda: None)
+    monkeypatch.setattr(implement_issue, "unblock_ready_issues", lambda: None)
+
+    captured_dirs = []
+
+    def fake_detect(project_dir=None):
+        captured_dirs.append(project_dir)
+        return False
+
+    monkeypatch.setattr(implement_issue, "detect_active_claude_session", fake_detect)
+
+    implement_issue.cfg = None
+    implement_issue.main()
+
+    assert len(captured_dirs) == 1
+    assert captured_dirs[0] is not None, "main() must pass an explicit project_dir"
 
 
 # --- truncate_spec tests ---


### PR DESCRIPTION
Closes #82

## Summary
fix: session detection blocks implement when Claude runs in a different directory

## Test Plan
- `uv run pytest` — all tests pass

## AutoLoop Run Stats
- Attempts: 3/3
- Duration: 734s
- Input tokens: 80
- Output tokens: 25,579
- Cost: $2.84

Automated implementation by AutoLoop.