### PR TITLE
feat: feat: add review_model and test_gate_skip_types config field (#88)

### DIFF
--- a/src/autoloop/config.py
+++ b/src/autoloop/config.py
@@ -32,6 +32,7 @@ class AutoLoopConfig:
     test_pattern: str = "tests/*.py"
     timer_prefix: str = "autoloop"
     protected_paths: list[str] = field(default_factory=lambda: ["autoloop/"])
+    review_model: str = ""
     test_gate_skip_types: list[str] = field(default_factory=lambda: ["refactor", "docs", "chore"])
     triage_labels: list[str] = field(
         default_factory=lambda: [
@@ -77,6 +78,7 @@ def load_config(path: Path | None = None) -> AutoLoopConfig:
         "repo",
         "triage_model",
         "impl_model",
+        "review_model",
         "pr_reviewer",
         "verify_cmd",
         "lint_command",
@@ -108,6 +110,9 @@ def load_config(path: Path | None = None) -> AutoLoopConfig:
 
     if "triage_labels" in data:
         config.triage_labels = list(data["triage_labels"])
+
+    if not config.review_model:
+        config.review_model = config.impl_model
 
     for env_var, (attr, coerce) in _ENV_MAP.items():
         if value := os.environ.get(env_var):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -229,6 +229,63 @@ def test_test_pattern_empty_from_toml(tmp_path, monkeypatch):
     assert config.test_pattern == ""
 
 
+def test_review_model_explicit_from_toml(tmp_path, monkeypatch):
+    for var in (
+        "AUTOLOOP_TRIAGE_MODEL",
+        "AUTOLOOP_IMPL_MODEL",
+        "AUTOLOOP_TIMEOUT",
+        "AUTOLOOP_REVIEWER",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    toml_path = tmp_path / "autoloop.toml"
+    toml_path.write_text('impl_model = "opus"\nreview_model = "sonnet"\n')
+    config = load_config(toml_path)
+    assert config.review_model == "sonnet"
+
+
+def test_review_model_defaults_to_impl_model(tmp_path, monkeypatch):
+    for var in (
+        "AUTOLOOP_TRIAGE_MODEL",
+        "AUTOLOOP_IMPL_MODEL",
+        "AUTOLOOP_TIMEOUT",
+        "AUTOLOOP_REVIEWER",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    toml_path = tmp_path / "autoloop.toml"
+    toml_path.write_text('impl_model = "opus"\n')
+    config = load_config(toml_path)
+    assert config.review_model == "opus"
+    assert config.review_model == config.impl_model
+
+
+def test_test_gate_skip_types_explicit_from_toml(tmp_path, monkeypatch):
+    for var in (
+        "AUTOLOOP_TRIAGE_MODEL",
+        "AUTOLOOP_IMPL_MODEL",
+        "AUTOLOOP_TIMEOUT",
+        "AUTOLOOP_REVIEWER",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    toml_path = tmp_path / "autoloop.toml"
+    toml_path.write_text('test_gate_skip_types = ["ci", "test"]\n')
+    config = load_config(toml_path)
+    assert config.test_gate_skip_types == ["ci", "test"]
+
+
+def test_test_gate_skip_types_defaults(tmp_path, monkeypatch):
+    for var in (
+        "AUTOLOOP_TRIAGE_MODEL",
+        "AUTOLOOP_IMPL_MODEL",
+        "AUTOLOOP_TIMEOUT",
+        "AUTOLOOP_REVIEWER",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    toml_path = tmp_path / "autoloop.toml"
+    toml_path.write_text('repo = "acme-corp/widget"\n')
+    config = load_config(toml_path)
+    assert config.test_gate_skip_types == ["refactor", "docs", "chore"]
+
+
 def test_protected_paths_default():
     config = AutoLoopConfig()
     assert config.protected_paths == ["autoloop/"]


### PR DESCRIPTION
Closes #88

## Summary
feat: add review_model and test_gate_skip_types config fields

## Test Plan
- `uv run pytest` — all tests pass

## AutoLoop Run Stats
- Attempts: 1/3
- Duration: 102s
- Input tokens: 12
- Output tokens: 2,925
- Cost: $0.37

Automated implementation by AutoLoop.