### PR TITLE
feat: feat: add review_model field to AutoLoopConfig and TOML load (#92)

### DIFF
--- a/src/autoloop/config.py
+++ b/src/autoloop/config.py
@@ -43,7 +43,12 @@ class AutoLoopConfig:
             "needs-human",
         ]
     )
+    review_model: str | None = None
     project_dir: str = ""
+
+    def __post_init__(self):
+        if self.review_model is None:
+            self.review_model = self.impl_model
 
 
 _ENV_MAP: dict[str, tuple[str, type]] = {
@@ -112,6 +117,11 @@ def load_config(path: Path | None = None) -> AutoLoopConfig:
     for env_var, (attr, coerce) in _ENV_MAP.items():
         if value := os.environ.get(env_var):
             setattr(config, attr, coerce(value))
+
+    if "review_model" in data:
+        config.review_model = data["review_model"]
+    else:
+        config.review_model = config.impl_model
 
     return config
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -234,6 +234,48 @@ def test_protected_paths_default():
     assert config.protected_paths == ["autoloop/"]
 
 
+def test_review_model_defaults_to_impl_model_in_dataclass():
+    config = AutoLoopConfig(impl_model="opus")
+    assert config.review_model == "opus"
+
+
+def test_review_model_defaults_to_impl_model_when_absent_from_toml(autoloop_toml, monkeypatch):
+    for var in (
+        "AUTOLOOP_TRIAGE_MODEL",
+        "AUTOLOOP_IMPL_MODEL",
+        "AUTOLOOP_TIMEOUT",
+        "AUTOLOOP_REVIEWER",
+        "AUTOLOOP_TRIAGE_TIMEOUT",
+        "AUTOLOOP_TEST_TIMEOUT",
+        "AUTOLOOP_MAX_RETRIES",
+        "AUTOLOOP_REPO",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    config = load_config(autoloop_toml)
+    assert config.review_model == config.impl_model
+
+
+def test_review_model_loaded_from_toml(tmp_path, monkeypatch):
+    for var in (
+        "AUTOLOOP_TRIAGE_MODEL",
+        "AUTOLOOP_IMPL_MODEL",
+        "AUTOLOOP_TIMEOUT",
+        "AUTOLOOP_REVIEWER",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    toml_path = tmp_path / "autoloop.toml"
+    toml_path.write_text('impl_model = "opus"\nreview_model = "sonnet"\n')
+    config = load_config(toml_path)
+    assert config.review_model == "sonnet"
+    assert config.impl_model == "opus"
+
+
+def test_review_model_accessible_without_passing_it():
+    config = AutoLoopConfig()
+    assert hasattr(config, "review_model")
+    assert config.review_model == config.impl_model
+
+
 def test_protected_paths_loaded_from_toml(tmp_path, monkeypatch):
     for var in (
         "AUTOLOOP_TRIAGE_MODEL",


### PR DESCRIPTION
Closes #92

## Summary
feat: add review_model field to AutoLoopConfig and TOML loader

## Test Plan
- `uv run pytest` — all tests pass

## AutoLoop Run Stats
- Attempts: 1/3
- Duration: 195s
- Input tokens: 14
- Output tokens: 6,780
- Cost: $0.57

Automated implementation by AutoLoop.