### PR TITLE
feat: feat: track and report cost for review-pr runs (#108)

### DIFF
--- a/src/autoloop/cli.py
+++ b/src/autoloop/cli.py
@@ -214,6 +214,16 @@ def review_pr(pr_number, cfg):
     )
     if checkout.returncode != 0:
         print(f"Failed to checkout PR #{pr_number}")
+        elapsed = time.time() - start_time
+        impl.log_run(
+            issue_number=0,
+            success=False,
+            attempts=1,
+            duration=elapsed,
+            cost_usd=0,
+            run_type="review",
+            pr_number=pr_number,
+        )
         return _zero_result
 
     try:
@@ -233,6 +243,16 @@ def review_pr(pr_number, cfg):
         )
         if pr_view.returncode != 0:
             print(f"Failed to get PR #{pr_number} info")
+            elapsed = time.time() - start_time
+            impl.log_run(
+                issue_number=0,
+                success=False,
+                attempts=1,
+                duration=elapsed,
+                cost_usd=0,
+                run_type="review",
+                pr_number=pr_number,
+            )
             return _zero_result
 
         pr_data = json.loads(pr_view.stdout)
@@ -350,45 +370,25 @@ def review_pr(pr_number, cfg):
 
 def _show_status():
     """Show last run, ready issues, and next scheduled timers."""
-    import json
-    from pathlib import Path
-
     from autoloop.config import load_config
+    from autoloop.mcp_server import _read_last_runs
 
     cfg = load_config()
 
-    log_file = Path.cwd() / "autoloop" / "run_history.jsonl"
-    if log_file.exists():
-        lines = log_file.read_text().strip().splitlines()
-        if lines:
-            last_impl = None
-            last_review = None
-            for line in reversed(lines):
-                entry = json.loads(line)
-                run_type = entry.get("type", "implement")
-                if run_type == "review" and last_review is None:
-                    last_review = entry
-                elif run_type != "review" and last_impl is None:
-                    last_impl = entry
-                if last_impl and last_review:
-                    break
-            if last_impl:
-                print(
-                    f"Last implement: issue #{last_impl['issue']} — "
-                    f"{'success' if last_impl['success'] else 'failed'} — "
-                    f"${last_impl.get('cost_usd', 0):.2f} — {last_impl['timestamp']}"
-                )
-            if last_review:
-                print(
-                    f"Last review: PR #{last_review['pr_number']} — "
-                    f"{'success' if last_review['success'] else 'failed'} — "
-                    f"${last_review.get('cost_usd', 0):.2f} — {last_review['timestamp']}"
-                )
-            if not last_impl and not last_review:
-                print("No run history yet.")
-        else:
-            print("No run history yet.")
-    else:
+    last_impl, last_review = _read_last_runs()
+    if last_impl:
+        print(
+            f"Last implement: issue #{last_impl['issue']} — "
+            f"{'success' if last_impl['success'] else 'failed'} — "
+            f"${last_impl.get('cost_usd', 0):.2f} — {last_impl['timestamp']}"
+        )
+    if last_review:
+        print(
+            f"Last review: PR #{last_review['pr_number']} — "
+            f"{'success' if last_review['success'] else 'failed'} — "
+            f"${last_review.get('cost_usd', 0):.2f} — {last_review['timestamp']}"
+        )
+    if not last_impl and not last_review:
         print("No run history yet.")
 
     import subprocess

--- a/src/autoloop/cli.py
+++ b/src/autoloop/cli.py
@@ -180,12 +180,16 @@ def review_pr(pr_number, cfg):
 
     Never merges. Applies needs-human label on failure.
     Restores the previous branch after review.
+    Returns (success, cost_usd, input_tokens, output_tokens) tuple.
     """
+    import time
+
     import autoloop.implement_issue as impl
     from autoloop.claude_runner import run_claude
     from autoloop.config import REPO_DIR
 
     impl.cfg = cfg
+    start_time = time.time()
 
     original_branch = subprocess.run(
         ["git", "rev-parse", "--abbrev-ref", "HEAD"],
@@ -250,14 +254,22 @@ def review_pr(pr_number, cfg):
                 "Review call failed (timeout or non-zero exit).",
             )
 
+        cost_line = (
+            f"\n\n**Review cost:** ${result.cost_usd:.2f}, "
+            f"tokens: {result.input_tokens:,} input / {result.output_tokens:,} output"
+        )
+
         findings = []
         if not gate_passed:
             findings.append(f"**Mutation gate failed:**\n```\n{gate_errors}\n```")
         if not review_passed:
             findings.append(f"**Semantic review failed:**\n{review_feedback}")
 
+        elapsed = time.time() - start_time
+        success = not findings
+
         if findings:
-            comment = "\n\n".join(findings)
+            comment = "\n\n".join(findings) + cost_line
             subprocess.run(
                 [
                     "gh",
@@ -282,21 +294,37 @@ def review_pr(pr_number, cfg):
                     "needs-human",
                 ],
             )
-            return False
+        else:
+            comment = (
+                "**Review passed:** mutation gate and semantic review both passed." + cost_line
+            )
+            subprocess.run(
+                [
+                    "gh",
+                    "pr",
+                    "comment",
+                    str(pr_number),
+                    "--repo",
+                    cfg.repo,
+                    "--body",
+                    comment,
+                ],
+            )
 
-        subprocess.run(
-            [
-                "gh",
-                "pr",
-                "comment",
-                str(pr_number),
-                "--repo",
-                cfg.repo,
-                "--body",
-                "**Review passed:** mutation gate and semantic review both passed.",
-            ],
+        impl.log_run(
+            issue_number=0,
+            success=success,
+            attempts=1,
+            duration=elapsed,
+            cost_usd=result.cost_usd,
+            input_tokens=result.input_tokens,
+            output_tokens=result.output_tokens,
+            cache_read_tokens=result.cache_read_tokens,
+            run_type="review",
+            pr_number=pr_number,
         )
-        return True
+
+        return success
     finally:
         subprocess.run(
             ["git", "checkout", original_branch],
@@ -318,12 +346,31 @@ def _show_status():
     if log_file.exists():
         lines = log_file.read_text().strip().splitlines()
         if lines:
-            last = json.loads(lines[-1])
-            print(
-                f"Last run: issue #{last['issue']} — "
-                f"{'success' if last['success'] else 'failed'} — "
-                f"${last.get('cost_usd', 0):.2f} — {last['timestamp']}"
-            )
+            last_impl = None
+            last_review = None
+            for line in reversed(lines):
+                entry = json.loads(line)
+                run_type = entry.get("type", "implement")
+                if run_type == "review" and last_review is None:
+                    last_review = entry
+                elif run_type != "review" and last_impl is None:
+                    last_impl = entry
+                if last_impl and last_review:
+                    break
+            if last_impl:
+                print(
+                    f"Last implement: issue #{last_impl['issue']} — "
+                    f"{'success' if last_impl['success'] else 'failed'} — "
+                    f"${last_impl.get('cost_usd', 0):.2f} — {last_impl['timestamp']}"
+                )
+            if last_review:
+                print(
+                    f"Last review: PR #{last_review['pr_number']} — "
+                    f"{'success' if last_review['success'] else 'failed'} — "
+                    f"${last_review.get('cost_usd', 0):.2f} — {last_review['timestamp']}"
+                )
+            if not last_impl and not last_review:
+                print("No run history yet.")
         else:
             print("No run history yet.")
     else:

--- a/src/autoloop/cli.py
+++ b/src/autoloop/cli.py
@@ -134,8 +134,8 @@ def main():
         from autoloop.config import load_config
 
         cfg = load_config()
-        success = review_pr(args.pr_number, cfg)
-        if not success:
+        result = review_pr(args.pr_number, cfg)
+        if not result["success"]:
             sys.exit(1)
 
     elif args.command == "auto-close-parent":
@@ -180,13 +180,22 @@ def review_pr(pr_number, cfg):
 
     Never merges. Applies needs-human label on failure.
     Restores the previous branch after review.
-    Returns True on success, False on failure.
+    Returns a dict with keys: success, cost_usd, input_tokens, output_tokens,
+    cache_read_tokens.
     """
     import time
 
     import autoloop.implement_issue as impl
     from autoloop.claude_runner import run_claude
     from autoloop.config import REPO_DIR
+
+    _zero_result = {
+        "success": False,
+        "cost_usd": 0,
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_tokens": 0,
+    }
 
     impl.cfg = cfg
     start_time = time.time()
@@ -205,7 +214,7 @@ def review_pr(pr_number, cfg):
     )
     if checkout.returncode != 0:
         print(f"Failed to checkout PR #{pr_number}")
-        return False
+        return _zero_result
 
     try:
         pr_view = subprocess.run(
@@ -224,7 +233,7 @@ def review_pr(pr_number, cfg):
         )
         if pr_view.returncode != 0:
             print(f"Failed to get PR #{pr_number} info")
-            return False
+            return _zero_result
 
         pr_data = json.loads(pr_view.stdout)
         branch = pr_data["headRefName"]
@@ -324,7 +333,13 @@ def review_pr(pr_number, cfg):
             pr_number=pr_number,
         )
 
-        return success
+        return {
+            "success": success,
+            "cost_usd": result.cost_usd,
+            "input_tokens": result.input_tokens,
+            "output_tokens": result.output_tokens,
+            "cache_read_tokens": result.cache_read_tokens,
+        }
     finally:
         subprocess.run(
             ["git", "checkout", original_branch],

--- a/src/autoloop/cli.py
+++ b/src/autoloop/cli.py
@@ -180,7 +180,7 @@ def review_pr(pr_number, cfg):
 
     Never merges. Applies needs-human label on failure.
     Restores the previous branch after review.
-    Returns (success, cost_usd, input_tokens, output_tokens) tuple.
+    Returns True on success, False on failure.
     """
     import time
 

--- a/src/autoloop/implement_issue.py
+++ b/src/autoloop/implement_issue.py
@@ -175,10 +175,13 @@ def log_run(
     input_tokens: int = 0,
     output_tokens: int = 0,
     cache_read_tokens: int = 0,
+    run_type: str = "implement",
+    pr_number: int | None = None,
 ):
     """Append a JSON entry to the run history log."""
     entry = {
         "timestamp": datetime.now(UTC).isoformat(),
+        "type": run_type,
         "issue": issue_number,
         "success": success,
         "attempts": attempts,
@@ -188,6 +191,8 @@ def log_run(
         "output_tokens": output_tokens,
         "cache_read_tokens": cache_read_tokens,
     }
+    if pr_number is not None:
+        entry["pr_number"] = pr_number
     LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
     with open(LOG_FILE, "a") as f:
         f.write(json.dumps(entry) + "\n")

--- a/src/autoloop/mcp_server.py
+++ b/src/autoloop/mcp_server.py
@@ -14,17 +14,6 @@ import subprocess
 from pathlib import Path
 
 
-def _read_last_run(base: Path | None = None) -> dict | None:
-    """Read the last entry from run_history.jsonl."""
-    log_file = (base or Path.cwd()) / "autoloop" / "run_history.jsonl"
-    if not log_file.exists():
-        return None
-    lines = log_file.read_text().strip().splitlines()
-    if not lines:
-        return None
-    return json.loads(lines[-1])
-
-
 def _read_last_runs(base: Path | None = None) -> tuple[dict | None, dict | None]:
     """Read the last implement and last review entries from run_history.jsonl."""
     log_file = (base or Path.cwd()) / "autoloop" / "run_history.jsonl"

--- a/src/autoloop/mcp_server.py
+++ b/src/autoloop/mcp_server.py
@@ -133,12 +133,34 @@ def main():
     def autoloop_review_pr(pr_number: int, repo_dir: str | None = None) -> str:
         """Review a PR (mutation gate + semantic review, no merge).
 
+        Runs synchronously and returns the review result with cost information.
+
         Args:
             pr_number: The PR number to review.
             repo_dir: Target repository directory. Defaults to server's working directory.
         """
-        _spawn(["autoloop", "review-pr", str(pr_number)], cwd=repo_dir)
-        return f"Started review-pr for PR #{pr_number}."
+        from autoloop.cli import review_pr
+        from autoloop.config import load_config
+
+        base = Path(repo_dir) if repo_dir else Path.cwd()
+        cfg = load_config(path=base / "autoloop.toml")
+        success = review_pr(pr_number, cfg)
+
+        status = "passed" if success else "failed"
+        log_file = base / "autoloop" / "run_history.jsonl"
+        if log_file.exists():
+            lines = log_file.read_text().strip().splitlines()
+            if lines:
+                entry = json.loads(lines[-1])
+                if entry.get("type") == "review" and entry.get("pr_number") == pr_number:
+                    cost = entry.get("cost_usd", 0)
+                    inp = entry.get("input_tokens", 0)
+                    out = entry.get("output_tokens", 0)
+                    return (
+                        f"Review {status} for PR #{pr_number}. "
+                        f"Cost: ${cost:.2f}, tokens: {inp:,} input / {out:,} output."
+                    )
+        return f"Review {status} for PR #{pr_number}."
 
     @server.tool()
     def autoloop_preflight(repo_dir: str | None = None) -> str:

--- a/src/autoloop/mcp_server.py
+++ b/src/autoloop/mcp_server.py
@@ -25,6 +25,28 @@ def _read_last_run(base: Path | None = None) -> dict | None:
     return json.loads(lines[-1])
 
 
+def _read_last_runs(base: Path | None = None) -> tuple[dict | None, dict | None]:
+    """Read the last implement and last review entries from run_history.jsonl."""
+    log_file = (base or Path.cwd()) / "autoloop" / "run_history.jsonl"
+    if not log_file.exists():
+        return None, None
+    lines = log_file.read_text().strip().splitlines()
+    if not lines:
+        return None, None
+    last_impl = None
+    last_review = None
+    for line in reversed(lines):
+        entry = json.loads(line)
+        run_type = entry.get("type", "implement")
+        if run_type == "review" and last_review is None:
+            last_review = entry
+        elif run_type != "review" and last_impl is None:
+            last_impl = entry
+        if last_impl and last_review:
+            break
+    return last_impl, last_review
+
+
 def _get_timer_info(prefix: str = "autoloop") -> dict[str, str]:
     """Parse systemd timer state for timers matching the given prefix."""
     try:
@@ -130,37 +152,35 @@ def main():
         return f"Started fix-pr for PR #{pr_number}."
 
     @server.tool()
-    def autoloop_review_pr(pr_number: int, repo_dir: str | None = None) -> str:
+    async def autoloop_review_pr(pr_number: int, repo_dir: str | None = None) -> str:
         """Review a PR (mutation gate + semantic review, no merge).
 
-        Runs synchronously and returns the review result with cost information.
+        Returns the review result with cost information. Runs in a thread
+        so it does not block the MCP server for other callers.
 
         Args:
             pr_number: The PR number to review.
             repo_dir: Target repository directory. Defaults to server's working directory.
         """
+        import asyncio
+
         from autoloop.cli import review_pr
         from autoloop.config import load_config
 
         base = Path(repo_dir) if repo_dir else Path.cwd()
         cfg = load_config(path=base / "autoloop.toml")
-        success = review_pr(pr_number, cfg)
 
-        status = "passed" if success else "failed"
-        log_file = base / "autoloop" / "run_history.jsonl"
-        if log_file.exists():
-            lines = log_file.read_text().strip().splitlines()
-            if lines:
-                entry = json.loads(lines[-1])
-                if entry.get("type") == "review" and entry.get("pr_number") == pr_number:
-                    cost = entry.get("cost_usd", 0)
-                    inp = entry.get("input_tokens", 0)
-                    out = entry.get("output_tokens", 0)
-                    return (
-                        f"Review {status} for PR #{pr_number}. "
-                        f"Cost: ${cost:.2f}, tokens: {inp:,} input / {out:,} output."
-                    )
-        return f"Review {status} for PR #{pr_number}."
+        loop = asyncio.get_event_loop()
+        result = await loop.run_in_executor(None, review_pr, pr_number, cfg)
+
+        status = "passed" if result["success"] else "failed"
+        cost = result["cost_usd"]
+        inp = result["input_tokens"]
+        out = result["output_tokens"]
+        return (
+            f"Review {status} for PR #{pr_number}. "
+            f"Cost: ${cost:.2f}, tokens: {inp:,} input / {out:,} output."
+        )
 
     @server.tool()
     def autoloop_preflight(repo_dir: str | None = None) -> str:
@@ -185,14 +205,20 @@ def main():
         parts = []
         cfg = load_config(path=base / "autoloop.toml")
 
-        last = _read_last_run(base)
-        if last:
-            status = "success" if last["success"] else "failed"
+        last_impl, last_review = _read_last_runs(base)
+        if last_impl:
+            status = "success" if last_impl["success"] else "failed"
             parts.append(
-                f"Last run: issue #{last['issue']} — {status} — "
-                f"${last.get('cost_usd', 0):.2f} — {last['timestamp']}"
+                f"Last implement: issue #{last_impl['issue']} — {status} — "
+                f"${last_impl.get('cost_usd', 0):.2f} — {last_impl['timestamp']}"
             )
-        else:
+        if last_review:
+            status = "success" if last_review["success"] else "failed"
+            parts.append(
+                f"Last review: PR #{last_review['pr_number']} — {status} — "
+                f"${last_review.get('cost_usd', 0):.2f} — {last_review['timestamp']}"
+            )
+        if not last_impl and not last_review:
             parts.append("Last run: no history")
 
         lockfile = base / ".autoloop.lock"

--- a/tests/test_implement_issue.py
+++ b/tests/test_implement_issue.py
@@ -1019,6 +1019,27 @@ def test_log_run_writes_json_entry(tmp_path, monkeypatch):
     entry = json.loads(lines[0])
     assert entry["issue"] == 17
     assert entry["success"] is True
+    assert entry["type"] == "implement"
+    assert "pr_number" not in entry
+
+
+def test_log_run_review_entry_includes_cost_fields(tmp_path, monkeypatch):
+    log_path = tmp_path / "run_history.jsonl"
+    monkeypatch.setattr(implement_issue, "LOG_FILE", log_path)
+    log_run(0, True, 1, 30.0, 0.12, 1500, 300, 100, run_type="review", pr_number=42)
+
+    lines = log_path.read_text().strip().splitlines()
+    assert len(lines) == 1
+    entry = json.loads(lines[0])
+    assert entry["type"] == "review"
+    assert entry["pr_number"] == 42
+    assert entry["success"] is True
+    assert entry["cost_usd"] == 0.12
+    assert entry["input_tokens"] == 1500
+    assert entry["output_tokens"] == 300
+    assert entry["cache_read_tokens"] == 100
+    assert entry["duration_seconds"] == 30
+    assert "timestamp" in entry
 
 
 # --- create_branch tests ---

--- a/tests/test_mcp_repo_dir.py
+++ b/tests/test_mcp_repo_dir.py
@@ -214,34 +214,99 @@ def test_review_pr_registered(mcp_tools):
     assert "autoloop_review_pr" in mcp_tools
 
 
-def test_review_pr_passes_cwd(mcp_tools, tmp_path):
-    """autoloop_review_pr passes repo_dir as cwd to Popen."""
-    captured = []
+def test_review_pr_returns_cost_from_log(mcp_tools, tmp_path, monkeypatch):
+    """autoloop_review_pr returns cost info from run_history.jsonl."""
+    toml_path = tmp_path / "autoloop.toml"
+    toml_path.write_text('repo = "acme-corp/widget"\n')
+    for var in (
+        "AUTOLOOP_TRIAGE_MODEL",
+        "AUTOLOOP_IMPL_MODEL",
+        "AUTOLOOP_TIMEOUT",
+        "AUTOLOOP_REVIEWER",
+        "AUTOLOOP_REPO",
+    ):
+        monkeypatch.delenv(var, raising=False)
 
-    def fake_popen(cmd, **kwargs):
-        captured.append({"cmd": cmd, "kwargs": kwargs})
+    log_dir = tmp_path / "autoloop"
+    log_dir.mkdir()
+    log_file = log_dir / "run_history.jsonl"
+    log_file.write_text(
+        json.dumps(
+            {
+                "type": "review",
+                "pr_number": 55,
+                "success": True,
+                "cost_usd": 0.12,
+                "input_tokens": 1500,
+                "output_tokens": 300,
+            }
+        )
+        + "\n"
+    )
 
-    with patch("autoloop.mcp_server.subprocess.Popen", fake_popen):
+    with patch("autoloop.cli.review_pr", return_value=True):
         result = mcp_tools["autoloop_review_pr"](pr_number=55, repo_dir=str(tmp_path))
 
-    assert len(captured) == 1
-    assert captured[0]["kwargs"]["cwd"] == str(tmp_path)
-    assert captured[0]["cmd"] == ["autoloop", "review-pr", "55"]
-    assert result == "Started review-pr for PR #55."
+    assert "passed" in result
+    assert "$0.12" in result
+    assert "1,500 input" in result
+    assert "300 output" in result
 
 
-def test_review_pr_cwd_none_when_no_repo_dir(mcp_tools):
-    """autoloop_review_pr passes cwd=None when repo_dir omitted."""
-    captured = []
+def test_review_pr_failure_returns_status(mcp_tools, tmp_path, monkeypatch):
+    """autoloop_review_pr returns failure status with cost."""
+    toml_path = tmp_path / "autoloop.toml"
+    toml_path.write_text('repo = "acme-corp/widget"\n')
+    for var in (
+        "AUTOLOOP_TRIAGE_MODEL",
+        "AUTOLOOP_IMPL_MODEL",
+        "AUTOLOOP_TIMEOUT",
+        "AUTOLOOP_REVIEWER",
+        "AUTOLOOP_REPO",
+    ):
+        monkeypatch.delenv(var, raising=False)
 
-    def fake_popen(cmd, **kwargs):
-        captured.append({"cmd": cmd, "kwargs": kwargs})
+    log_dir = tmp_path / "autoloop"
+    log_dir.mkdir()
+    log_file = log_dir / "run_history.jsonl"
+    log_file.write_text(
+        json.dumps(
+            {
+                "type": "review",
+                "pr_number": 55,
+                "success": False,
+                "cost_usd": 0.08,
+                "input_tokens": 1000,
+                "output_tokens": 200,
+            }
+        )
+        + "\n"
+    )
 
-    with patch("autoloop.mcp_server.subprocess.Popen", fake_popen):
-        mcp_tools["autoloop_review_pr"](pr_number=1)
+    with patch("autoloop.cli.review_pr", return_value=False):
+        result = mcp_tools["autoloop_review_pr"](pr_number=55, repo_dir=str(tmp_path))
 
-    assert len(captured) == 1
-    assert captured[0]["kwargs"]["cwd"] is None
+    assert "failed" in result
+    assert "$0.08" in result
+
+
+def test_review_pr_no_log_returns_basic_status(mcp_tools, tmp_path, monkeypatch):
+    """autoloop_review_pr returns basic status when no log exists."""
+    toml_path = tmp_path / "autoloop.toml"
+    toml_path.write_text('repo = "acme-corp/widget"\n')
+    for var in (
+        "AUTOLOOP_TRIAGE_MODEL",
+        "AUTOLOOP_IMPL_MODEL",
+        "AUTOLOOP_TIMEOUT",
+        "AUTOLOOP_REVIEWER",
+        "AUTOLOOP_REPO",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+    with patch("autoloop.cli.review_pr", return_value=True):
+        result = mcp_tools["autoloop_review_pr"](pr_number=55, repo_dir=str(tmp_path))
+
+    assert result == "Review passed for PR #55."
 
 
 def test_status_with_repo_dir(mcp_tools, tmp_path, monkeypatch):

--- a/tests/test_mcp_repo_dir.py
+++ b/tests/test_mcp_repo_dir.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 
 import pytest
 
-from autoloop.mcp_server import _read_last_run
+from autoloop.mcp_server import _read_last_run, _read_last_runs
 
 
 # --- _read_last_run with base parameter ---
@@ -39,6 +39,68 @@ def test_read_last_run_without_base_uses_cwd(tmp_path, monkeypatch):
 
     result = _read_last_run()
     assert result["issue"] == 3
+
+
+# --- _read_last_runs ---
+
+
+def test_read_last_runs_returns_both(tmp_path):
+    log_dir = tmp_path / "autoloop"
+    log_dir.mkdir()
+    log_file = log_dir / "run_history.jsonl"
+    lines = [
+        json.dumps({"type": "implement", "issue": 10, "success": True, "timestamp": "t1"}),
+        json.dumps(
+            {
+                "type": "review",
+                "pr_number": 42,
+                "success": False,
+                "cost_usd": 0.08,
+                "timestamp": "t2",
+            }
+        ),
+    ]
+    log_file.write_text("\n".join(lines) + "\n")
+
+    last_impl, last_review = _read_last_runs(base=tmp_path)
+    assert last_impl["issue"] == 10
+    assert last_review["pr_number"] == 42
+    assert last_review["type"] == "review"
+
+
+def test_read_last_runs_no_file(tmp_path):
+    last_impl, last_review = _read_last_runs(base=tmp_path)
+    assert last_impl is None
+    assert last_review is None
+
+
+def test_read_last_runs_only_implement(tmp_path):
+    log_dir = tmp_path / "autoloop"
+    log_dir.mkdir()
+    log_file = log_dir / "run_history.jsonl"
+    log_file.write_text(
+        json.dumps({"type": "implement", "issue": 5, "success": True, "timestamp": "t1"}) + "\n"
+    )
+
+    last_impl, last_review = _read_last_runs(base=tmp_path)
+    assert last_impl["issue"] == 5
+    assert last_review is None
+
+
+def test_read_last_runs_only_review(tmp_path):
+    log_dir = tmp_path / "autoloop"
+    log_dir.mkdir()
+    log_file = log_dir / "run_history.jsonl"
+    log_file.write_text(
+        json.dumps(
+            {"type": "review", "pr_number": 7, "success": True, "cost_usd": 0.05, "timestamp": "t1"}
+        )
+        + "\n"
+    )
+
+    last_impl, last_review = _read_last_runs(base=tmp_path)
+    assert last_impl is None
+    assert last_review["pr_number"] == 7
 
 
 # --- Fake FastMCP for testing tool registration ---
@@ -214,8 +276,10 @@ def test_review_pr_registered(mcp_tools):
     assert "autoloop_review_pr" in mcp_tools
 
 
-def test_review_pr_returns_cost_from_log(mcp_tools, tmp_path, monkeypatch):
-    """autoloop_review_pr returns cost info from run_history.jsonl."""
+def test_review_pr_returns_cost_from_return_dict(mcp_tools, tmp_path, monkeypatch):
+    """autoloop_review_pr returns cost info from review_pr() return dict."""
+    import asyncio
+
     toml_path = tmp_path / "autoloop.toml"
     toml_path.write_text('repo = "acme-corp/widget"\n')
     for var in (
@@ -227,25 +291,16 @@ def test_review_pr_returns_cost_from_log(mcp_tools, tmp_path, monkeypatch):
     ):
         monkeypatch.delenv(var, raising=False)
 
-    log_dir = tmp_path / "autoloop"
-    log_dir.mkdir()
-    log_file = log_dir / "run_history.jsonl"
-    log_file.write_text(
-        json.dumps(
-            {
-                "type": "review",
-                "pr_number": 55,
-                "success": True,
-                "cost_usd": 0.12,
-                "input_tokens": 1500,
-                "output_tokens": 300,
-            }
-        )
-        + "\n"
-    )
+    review_result = {
+        "success": True,
+        "cost_usd": 0.12,
+        "input_tokens": 1500,
+        "output_tokens": 300,
+        "cache_read_tokens": 100,
+    }
 
-    with patch("autoloop.cli.review_pr", return_value=True):
-        result = mcp_tools["autoloop_review_pr"](pr_number=55, repo_dir=str(tmp_path))
+    with patch("autoloop.cli.review_pr", return_value=review_result):
+        result = asyncio.run(mcp_tools["autoloop_review_pr"](pr_number=55, repo_dir=str(tmp_path)))
 
     assert "passed" in result
     assert "$0.12" in result
@@ -255,6 +310,8 @@ def test_review_pr_returns_cost_from_log(mcp_tools, tmp_path, monkeypatch):
 
 def test_review_pr_failure_returns_status(mcp_tools, tmp_path, monkeypatch):
     """autoloop_review_pr returns failure status with cost."""
+    import asyncio
+
     toml_path = tmp_path / "autoloop.toml"
     toml_path.write_text('repo = "acme-corp/widget"\n')
     for var in (
@@ -266,47 +323,19 @@ def test_review_pr_failure_returns_status(mcp_tools, tmp_path, monkeypatch):
     ):
         monkeypatch.delenv(var, raising=False)
 
-    log_dir = tmp_path / "autoloop"
-    log_dir.mkdir()
-    log_file = log_dir / "run_history.jsonl"
-    log_file.write_text(
-        json.dumps(
-            {
-                "type": "review",
-                "pr_number": 55,
-                "success": False,
-                "cost_usd": 0.08,
-                "input_tokens": 1000,
-                "output_tokens": 200,
-            }
-        )
-        + "\n"
-    )
+    review_result = {
+        "success": False,
+        "cost_usd": 0.08,
+        "input_tokens": 1000,
+        "output_tokens": 200,
+        "cache_read_tokens": 50,
+    }
 
-    with patch("autoloop.cli.review_pr", return_value=False):
-        result = mcp_tools["autoloop_review_pr"](pr_number=55, repo_dir=str(tmp_path))
+    with patch("autoloop.cli.review_pr", return_value=review_result):
+        result = asyncio.run(mcp_tools["autoloop_review_pr"](pr_number=55, repo_dir=str(tmp_path)))
 
     assert "failed" in result
     assert "$0.08" in result
-
-
-def test_review_pr_no_log_returns_basic_status(mcp_tools, tmp_path, monkeypatch):
-    """autoloop_review_pr returns basic status when no log exists."""
-    toml_path = tmp_path / "autoloop.toml"
-    toml_path.write_text('repo = "acme-corp/widget"\n')
-    for var in (
-        "AUTOLOOP_TRIAGE_MODEL",
-        "AUTOLOOP_IMPL_MODEL",
-        "AUTOLOOP_TIMEOUT",
-        "AUTOLOOP_REVIEWER",
-        "AUTOLOOP_REPO",
-    ):
-        monkeypatch.delenv(var, raising=False)
-
-    with patch("autoloop.cli.review_pr", return_value=True):
-        result = mcp_tools["autoloop_review_pr"](pr_number=55, repo_dir=str(tmp_path))
-
-    assert result == "Review passed for PR #55."
 
 
 def test_status_with_repo_dir(mcp_tools, tmp_path, monkeypatch):
@@ -346,9 +375,59 @@ def test_status_with_repo_dir(mcp_tools, tmp_path, monkeypatch):
     with patch("autoloop.mcp_server.subprocess.run", fake_run):
         result = mcp_tools["autoloop_status"](repo_dir=str(tmp_path))
 
-    assert "issue #10" in result
+    assert "Last implement: issue #10" in result
     assert "success" in result
     assert "implementation" in result
+
+
+def test_status_shows_both_implement_and_review(mcp_tools, tmp_path, monkeypatch):
+    """autoloop_status shows last implement and last review side-by-side."""
+    toml_path = tmp_path / "autoloop.toml"
+    toml_path.write_text('repo = "acme-corp/widget"\n')
+
+    log_dir = tmp_path / "autoloop"
+    log_dir.mkdir()
+    lines = [
+        json.dumps(
+            {"issue": 10, "success": True, "cost_usd": 0.75, "timestamp": "2026-07-18T10:00:00"}
+        ),
+        json.dumps(
+            {
+                "type": "review",
+                "issue": 0,
+                "pr_number": 42,
+                "success": False,
+                "cost_usd": 0.12,
+                "timestamp": "2026-07-18T11:00:00",
+            }
+        ),
+    ]
+    (log_dir / "run_history.jsonl").write_text("\n".join(lines) + "\n")
+
+    for var in (
+        "AUTOLOOP_TRIAGE_MODEL",
+        "AUTOLOOP_IMPL_MODEL",
+        "AUTOLOOP_TIMEOUT",
+        "AUTOLOOP_REVIEWER",
+        "AUTOLOOP_REPO",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+    def fake_run(cmd, **kwargs):
+        if cmd[0] == "gh":
+            return type("R", (), {"returncode": 0, "stdout": "[]", "stderr": ""})()
+        if cmd[0] == "pgrep":
+            return type("R", (), {"returncode": 1, "stdout": "", "stderr": ""})()
+        if cmd[0] == "systemctl":
+            return type("R", (), {"returncode": 1, "stdout": "", "stderr": ""})()
+        return type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    with patch("autoloop.mcp_server.subprocess.run", fake_run):
+        result = mcp_tools["autoloop_status"](repo_dir=str(tmp_path))
+
+    assert "Last implement: issue #10" in result
+    assert "Last review: PR #42" in result
+    assert "failed" in result
 
 
 def test_status_without_repo_dir_uses_cwd(mcp_tools, tmp_path, monkeypatch):

--- a/tests/test_mcp_repo_dir.py
+++ b/tests/test_mcp_repo_dir.py
@@ -9,36 +9,7 @@ from unittest.mock import patch
 
 import pytest
 
-from autoloop.mcp_server import _read_last_run, _read_last_runs
-
-
-# --- _read_last_run with base parameter ---
-
-
-def test_read_last_run_with_base_path(tmp_path):
-    log_dir = tmp_path / "autoloop"
-    log_dir.mkdir()
-    log_file = log_dir / "run_history.jsonl"
-    log_file.write_text(json.dumps({"issue": 5, "success": True, "cost_usd": 0.25}) + "\n")
-
-    result = _read_last_run(base=tmp_path)
-    assert result["issue"] == 5
-    assert result["success"] is True
-
-
-def test_read_last_run_with_base_path_no_file(tmp_path):
-    assert _read_last_run(base=tmp_path) is None
-
-
-def test_read_last_run_without_base_uses_cwd(tmp_path, monkeypatch):
-    log_dir = tmp_path / "autoloop"
-    log_dir.mkdir()
-    log_file = log_dir / "run_history.jsonl"
-    log_file.write_text(json.dumps({"issue": 3, "success": False, "cost_usd": 0.10}) + "\n")
-    monkeypatch.setattr("autoloop.mcp_server.Path.cwd", lambda: tmp_path)
-
-    result = _read_last_run()
-    assert result["issue"] == 3
+from autoloop.mcp_server import _read_last_runs
 
 
 # --- _read_last_runs ---

--- a/tests/test_review_pr.py
+++ b/tests/test_review_pr.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import call, patch
 
@@ -33,13 +34,15 @@ def _ok(stdout="", returncode=0):
     return SimpleNamespace(returncode=returncode, stdout=stdout, stderr="")
 
 
-def _claude_result(text="", success=True):
+def _claude_result(
+    text="", success=True, cost_usd=0, input_tokens=0, output_tokens=0, cache_read_tokens=0
+):
     return SimpleNamespace(
         text=text,
-        cost_usd=0,
-        input_tokens=0,
-        output_tokens=0,
-        cache_read_tokens=0,
+        cost_usd=cost_usd,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cache_read_tokens=cache_read_tokens,
         success=success,
         timed_out=False,
     )
@@ -327,3 +330,137 @@ class TestReviewPrBranchRestore:
             c for c in all_calls if isinstance(c, list) and c == ["git", "checkout", "my-feature"]
         ]
         assert len(restore_calls) == 1
+
+
+class TestReviewPrCostTracking:
+    def test_success_logs_review_entry_with_cost_fields(self, tmp_path):
+        cfg = _cfg()
+        pr_data = json.dumps({"headRefName": "fix/42", "title": "Fix bug", "body": ""})
+        review_json = json.dumps({"approved": True, "summary": "looks good"})
+        dispatch = _make_dispatcher(pr_data)
+        log_file = tmp_path / "autoloop" / "run_history.jsonl"
+
+        with (
+            patch("subprocess.run", side_effect=dispatch),
+            patch(
+                "autoloop.claude_runner.run_claude",
+                return_value=_claude_result(
+                    text=review_json,
+                    cost_usd=0.12,
+                    input_tokens=1500,
+                    output_tokens=300,
+                    cache_read_tokens=100,
+                ),
+            ),
+            patch("autoloop.implement_issue.LOG_FILE", log_file),
+        ):
+            result = review_pr(42, cfg)
+
+        assert result is True
+        assert log_file.exists()
+        entry = json.loads(log_file.read_text().strip())
+        assert entry["type"] == "review"
+        assert entry["pr_number"] == 42
+        assert entry["success"] is True
+        assert entry["cost_usd"] == 0.12
+        assert entry["input_tokens"] == 1500
+        assert entry["output_tokens"] == 300
+        assert entry["cache_read_tokens"] == 100
+        assert "duration_seconds" in entry
+        assert "timestamp" in entry
+
+    def test_failure_logs_review_entry(self, tmp_path):
+        cfg = _cfg()
+        pr_data = json.dumps({"headRefName": "fix/42", "title": "Fix bug", "body": ""})
+        review_json = json.dumps(
+            {"approved": False, "issues": ["missing tests"], "summary": "needs work"}
+        )
+        dispatch = _make_dispatcher(pr_data)
+        log_file = tmp_path / "autoloop" / "run_history.jsonl"
+
+        with (
+            patch("subprocess.run", side_effect=dispatch),
+            patch(
+                "autoloop.claude_runner.run_claude",
+                return_value=_claude_result(text=review_json, cost_usd=0.08),
+            ),
+            patch("autoloop.implement_issue.LOG_FILE", log_file),
+        ):
+            result = review_pr(42, cfg)
+
+        assert result is False
+        entry = json.loads(log_file.read_text().strip())
+        assert entry["type"] == "review"
+        assert entry["pr_number"] == 42
+        assert entry["success"] is False
+        assert entry["cost_usd"] == 0.08
+
+    def test_success_comment_includes_cost_line(self):
+        cfg = _cfg()
+        pr_data = json.dumps({"headRefName": "fix/42", "title": "Fix bug", "body": ""})
+        review_json = json.dumps({"approved": True, "summary": "looks good"})
+        dispatch = _make_dispatcher(pr_data)
+
+        all_calls = []
+        original_dispatch = dispatch
+
+        def tracking_dispatch(*args, **kwargs):
+            cmd = args[0] if args else kwargs.get("args", [])
+            all_calls.append((cmd, kwargs))
+            return original_dispatch(*args, **kwargs)
+
+        with (
+            patch("subprocess.run", side_effect=tracking_dispatch),
+            patch(
+                "autoloop.claude_runner.run_claude",
+                return_value=_claude_result(
+                    text=review_json, cost_usd=0.15, input_tokens=2000, output_tokens=500
+                ),
+            ),
+            patch("autoloop.implement_issue.LOG_FILE", Path("/dev/null")),
+        ):
+            review_pr(42, cfg)
+
+        comment_calls = [
+            c for c, kw in all_calls if isinstance(c, list) and c[:3] == ["gh", "pr", "comment"]
+        ]
+        assert len(comment_calls) >= 1
+        body_idx = comment_calls[0].index("--body") + 1
+        body = comment_calls[0][body_idx]
+        assert "Review cost:" in body
+        assert "$0.15" in body
+        assert "2,000 input" in body
+        assert "500 output" in body
+
+    def test_failure_comment_includes_cost_line(self):
+        cfg = _cfg()
+        pr_data = json.dumps({"headRefName": "fix/42", "title": "Fix bug", "body": ""})
+        review_json = json.dumps({"approved": False, "issues": ["bad tests"], "summary": "no"})
+        dispatch = _make_dispatcher(pr_data)
+
+        all_calls = []
+        original_dispatch = dispatch
+
+        def tracking_dispatch(*args, **kwargs):
+            cmd = args[0] if args else kwargs.get("args", [])
+            all_calls.append((cmd, kwargs))
+            return original_dispatch(*args, **kwargs)
+
+        with (
+            patch("subprocess.run", side_effect=tracking_dispatch),
+            patch(
+                "autoloop.claude_runner.run_claude",
+                return_value=_claude_result(text=review_json, cost_usd=0.10),
+            ),
+            patch("autoloop.implement_issue.LOG_FILE", Path("/dev/null")),
+        ):
+            review_pr(42, cfg)
+
+        comment_calls = [
+            c for c, kw in all_calls if isinstance(c, list) and c[:3] == ["gh", "pr", "comment"]
+        ]
+        assert len(comment_calls) >= 1
+        body_idx = comment_calls[0].index("--body") + 1
+        body = comment_calls[0][body_idx]
+        assert "Review cost:" in body
+        assert "$0.10" in body

--- a/tests/test_review_pr.py
+++ b/tests/test_review_pr.py
@@ -469,3 +469,34 @@ class TestReviewPrCostTracking:
         body = comment_calls[0][body_idx]
         assert "Review cost:" in body
         assert "$0.10" in body
+
+    def test_checkout_failure_logs_run(self, tmp_path):
+        cfg = _cfg()
+        pr_data = json.dumps({"headRefName": "fix/42", "title": "Fix", "body": ""})
+        dispatch = _make_dispatcher(pr_data, {("gh", "pr", "checkout"): _ok(returncode=1)})
+        log_file = tmp_path / "run_history.jsonl"
+        with (
+            patch("subprocess.run", side_effect=dispatch),
+            patch("autoloop.implement_issue.LOG_FILE", log_file),
+        ):
+            review_pr(42, cfg)
+        entry = json.loads(log_file.read_text().strip())
+        assert entry["type"] == "review"
+        assert entry["pr_number"] == 42
+        assert entry["success"] is False
+        assert entry["cost_usd"] == 0
+
+    def test_pr_view_failure_logs_run(self, tmp_path):
+        cfg = _cfg()
+        dispatch = _make_dispatcher("", {("gh", "pr", "view"): _ok(returncode=1)})
+        log_file = tmp_path / "run_history.jsonl"
+        with (
+            patch("subprocess.run", side_effect=dispatch),
+            patch("autoloop.implement_issue.LOG_FILE", log_file),
+        ):
+            review_pr(42, cfg)
+        entry = json.loads(log_file.read_text().strip())
+        assert entry["type"] == "review"
+        assert entry["pr_number"] == 42
+        assert entry["success"] is False
+        assert entry["cost_usd"] == 0

--- a/tests/test_review_pr.py
+++ b/tests/test_review_pr.py
@@ -98,7 +98,7 @@ class TestReviewPrHandler:
         dispatch = _make_dispatcher(pr_data, {("gh", "pr", "checkout"): _ok(returncode=1)})
         with patch("subprocess.run", side_effect=dispatch) as mock_run:
             result = review_pr(42, cfg)
-        assert result is False
+        assert result["success"] is False
         checkout_calls = [
             c
             for c in mock_run.call_args_list
@@ -125,7 +125,7 @@ class TestReviewPrHandler:
             ),
         ):
             result = review_pr(42, cfg)
-        assert result is True
+        assert result["success"] is True
 
     def test_gate_failure_posts_comment_and_label(self):
         cfg = _cfg()
@@ -150,7 +150,7 @@ class TestReviewPrHandler:
         ):
             result = review_pr(42, cfg)
 
-        assert result is False
+        assert result["success"] is False
         comment_calls = [
             c for c in all_calls if isinstance(c, list) and c[:3] == ["gh", "pr", "comment"]
         ]
@@ -191,7 +191,7 @@ class TestReviewPrHandler:
         ):
             result = review_pr(42, cfg)
 
-        assert result is False
+        assert result["success"] is False
         comment_calls = [
             c for c in all_calls if isinstance(c, list) and c[:3] == ["gh", "pr", "comment"]
         ]
@@ -356,7 +356,11 @@ class TestReviewPrCostTracking:
         ):
             result = review_pr(42, cfg)
 
-        assert result is True
+        assert result["success"] is True
+        assert result["cost_usd"] == 0.12
+        assert result["input_tokens"] == 1500
+        assert result["output_tokens"] == 300
+        assert result["cache_read_tokens"] == 100
         assert log_file.exists()
         entry = json.loads(log_file.read_text().strip())
         assert entry["type"] == "review"
@@ -388,7 +392,8 @@ class TestReviewPrCostTracking:
         ):
             result = review_pr(42, cfg)
 
-        assert result is False
+        assert result["success"] is False
+        assert result["cost_usd"] == 0.08
         entry = json.loads(log_file.read_text().strip())
         assert entry["type"] == "review"
         assert entry["pr_number"] == 42

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -245,3 +245,107 @@ def test_timer_prefix_keeps_default_when_not_in_toml(tmp_path, monkeypatch):
 
     config = load_config(toml_path)
     assert config.timer_prefix == "autoloop"
+
+
+# --- CLI _show_status review display ---
+
+
+def test_cli_show_status_displays_review_run(tmp_path, monkeypatch, capsys):
+    from autoloop.config import AutoLoopConfig
+
+    monkeypatch.setattr(
+        "autoloop.config.load_config",
+        lambda path=None: AutoLoopConfig(repo="owner/repo"),
+    )
+
+    log_dir = tmp_path / "autoloop"
+    log_dir.mkdir()
+    log_file = log_dir / "run_history.jsonl"
+    log_file.write_text(
+        json.dumps(
+            {
+                "timestamp": "2026-09-01T12:00:00",
+                "type": "implement",
+                "issue": 10,
+                "success": True,
+                "cost_usd": 0.50,
+                "attempts": 1,
+                "duration_seconds": 60,
+            }
+        )
+        + "\n"
+        + json.dumps(
+            {
+                "timestamp": "2026-09-02T14:00:00",
+                "type": "review",
+                "pr_number": 42,
+                "success": True,
+                "cost_usd": 0.12,
+                "duration_seconds": 30,
+            }
+        )
+        + "\n"
+    )
+    monkeypatch.chdir(tmp_path)
+
+    def fake_run(cmd, **kwargs):
+        if cmd[0] == "gh":
+            return type("R", (), {"returncode": 0, "stdout": "[]", "stderr": ""})()
+        if cmd[0] == "systemctl":
+            return type("R", (), {"returncode": 1, "stdout": "", "stderr": ""})()
+        return type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    with patch("subprocess.run", fake_run):
+        import autoloop.cli
+
+        autoloop.cli._show_status()
+
+    out = capsys.readouterr().out
+    assert "Last implement: issue #10" in out
+    assert "$0.50" in out
+    assert "Last review: PR #42" in out
+    assert "$0.12" in out
+
+
+def test_cli_show_status_no_review_shows_implement_only(tmp_path, monkeypatch, capsys):
+    from autoloop.config import AutoLoopConfig
+
+    monkeypatch.setattr(
+        "autoloop.config.load_config",
+        lambda path=None: AutoLoopConfig(repo="owner/repo"),
+    )
+
+    log_dir = tmp_path / "autoloop"
+    log_dir.mkdir()
+    log_file = log_dir / "run_history.jsonl"
+    log_file.write_text(
+        json.dumps(
+            {
+                "timestamp": "2026-09-01T12:00:00",
+                "type": "implement",
+                "issue": 10,
+                "success": True,
+                "cost_usd": 0.50,
+                "attempts": 1,
+                "duration_seconds": 60,
+            }
+        )
+        + "\n"
+    )
+    monkeypatch.chdir(tmp_path)
+
+    def fake_run(cmd, **kwargs):
+        if cmd[0] == "gh":
+            return type("R", (), {"returncode": 0, "stdout": "[]", "stderr": ""})()
+        if cmd[0] == "systemctl":
+            return type("R", (), {"returncode": 1, "stdout": "", "stderr": ""})()
+        return type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    with patch("subprocess.run", fake_run):
+        import autoloop.cli
+
+        autoloop.cli._show_status()
+
+    out = capsys.readouterr().out
+    assert "Last implement: issue #10" in out
+    assert "Last review:" not in out

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -5,40 +5,7 @@ from __future__ import annotations
 import json
 from unittest.mock import patch
 
-from autoloop.mcp_server import _get_timer_info, _is_process_running, _read_last_run
-
-
-# --- _read_last_run ---
-
-
-def test_read_last_run_returns_last_entry(tmp_path, monkeypatch):
-    log_dir = tmp_path / "autoloop"
-    log_dir.mkdir()
-    log_file = log_dir / "run_history.jsonl"
-    log_file.write_text(
-        json.dumps({"issue": 1, "success": True, "cost_usd": 0.50})
-        + "\n"
-        + json.dumps({"issue": 2, "success": False, "cost_usd": 1.00})
-        + "\n"
-    )
-    monkeypatch.setattr("autoloop.mcp_server.Path.cwd", lambda: tmp_path)
-
-    result = _read_last_run()
-    assert result["issue"] == 2
-    assert result["success"] is False
-
-
-def test_read_last_run_returns_none_when_no_file(tmp_path, monkeypatch):
-    monkeypatch.setattr("autoloop.mcp_server.Path.cwd", lambda: tmp_path)
-    assert _read_last_run() is None
-
-
-def test_read_last_run_returns_none_when_empty_file(tmp_path, monkeypatch):
-    log_dir = tmp_path / "autoloop"
-    log_dir.mkdir()
-    (log_dir / "run_history.jsonl").write_text("")
-    monkeypatch.setattr("autoloop.mcp_server.Path.cwd", lambda: tmp_path)
-    assert _read_last_run() is None
+from autoloop.mcp_server import _get_timer_info, _is_process_running
 
 
 # --- _get_timer_info ---


### PR DESCRIPTION
Closes #108

## Summary
feat: track and report cost for review-pr runs

## Test Plan
- `uv run pytest` — all tests pass

## AutoLoop Run Stats
- Attempts: 3/3
- Duration: 983s
- Input tokens: 78
- Output tokens: 44,926
- Cost: $4.58

Automated implementation by AutoLoop.