### PR TITLE
fix: fix: review-pr should remove needs-human label when review p (#110)

### DIFF
--- a/src/autoloop/cli.py
+++ b/src/autoloop/cli.py
@@ -353,6 +353,21 @@ def review_pr(pr_number, cfg):
             pr_number=pr_number,
         )
 
+        if success:
+            subprocess.run(
+                [
+                    "gh",
+                    "pr",
+                    "edit",
+                    str(pr_number),
+                    "--repo",
+                    cfg.repo,
+                    "--remove-label",
+                    "needs-human",
+                ],
+                capture_output=True,
+            )
+
         return {
             "success": success,
             "cost_usd": result.cost_usd,

--- a/tests/test_review_pr.py
+++ b/tests/test_review_pr.py
@@ -271,6 +271,37 @@ class TestReviewPrHandler:
         ]
         assert len(label_calls) == 1
 
+    def test_needs_human_label_removed_on_pass(self):
+        cfg = _cfg()
+        pr_data = json.dumps({"headRefName": "fix/42", "title": "Fix bug", "body": ""})
+        review_json = json.dumps({"approved": True, "summary": "looks good"})
+        dispatch = _make_dispatcher(pr_data)
+
+        all_calls = []
+        original_dispatch = dispatch
+
+        def tracking_dispatch(*args, **kwargs):
+            cmd = args[0] if args else kwargs.get("args", [])
+            all_calls.append(cmd)
+            return original_dispatch(*args, **kwargs)
+
+        with (
+            patch("subprocess.run", side_effect=tracking_dispatch),
+            patch(
+                "autoloop.claude_runner.run_claude",
+                return_value=_claude_result(text=review_json),
+            ),
+        ):
+            result = review_pr(42, cfg)
+
+        assert result["success"] is True
+        remove_label_calls = [
+            c
+            for c in all_calls
+            if isinstance(c, list) and "--remove-label" in c and "needs-human" in c
+        ]
+        assert len(remove_label_calls) == 1
+
 
 class TestReviewPrBranchRestore:
     def test_restores_original_branch_on_success(self):


### PR DESCRIPTION
Closes #110

## Summary
fix: review-pr should remove needs-human label when review passes after prior failure

## Test Plan
- `uv run pytest` — all tests pass

## AutoLoop Run Stats
- Attempts: 1/3
- Duration: 103s
- Input tokens: 15
- Output tokens: 2,907
- Cost: $0.53

Automated implementation by AutoLoop.